### PR TITLE
Refactor track to its own collection

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -29,7 +29,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: server/
 
-      - run: npm ci
+      - run: npm ci --force
 
       - run: npm run lint
 

--- a/dashboard/src/pages/Track/index.tsx
+++ b/dashboard/src/pages/Track/index.tsx
@@ -2,7 +2,7 @@ import {
   faAdd,
   faCheck,
   faSearch,
-  faTrash,
+  faTrash
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
@@ -19,7 +19,7 @@ import {
   Form,
   InputGroup,
   ListGroup,
-  Row,
+  Row
 } from "react-bootstrap";
 import { useParams } from "react-router-dom";
 import {
@@ -27,14 +27,14 @@ import {
   TrackList,
   useFetchServerQuery,
   useLazySearchQuery,
-  useUpdateTrackMutation,
+  useUpdateTrackMutation
 } from "store/api";
 import {
   loadTrack,
   trackGuild,
   trackPlayer,
   untrackGuild,
-  untrackPlayer,
+  untrackPlayer
 } from "store/track";
 
 const Track = () => {
@@ -49,7 +49,7 @@ const Track = () => {
 
   useEffect(() => {
     if (server?.data?.settings) {
-      dispatch(loadTrack(server.data.settings.track));
+      dispatch(loadTrack(server.data.track));
     }
   }, [dispatch, server]);
 
@@ -225,7 +225,7 @@ const Track = () => {
                 variant="secondary"
                 onClick={() => {
                   if (server?.data?.settings)
-                    dispatch(loadTrack(server.data.settings.track));
+                    dispatch(loadTrack(server.data.track));
                 }}
               >
                 Reset

--- a/dashboard/src/pages/Track/index.tsx
+++ b/dashboard/src/pages/Track/index.tsx
@@ -2,7 +2,7 @@ import {
   faAdd,
   faCheck,
   faSearch,
-  faTrash
+  faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
@@ -19,7 +19,7 @@ import {
   Form,
   InputGroup,
   ListGroup,
-  Row
+  Row,
 } from "react-bootstrap";
 import { useParams } from "react-router-dom";
 import {
@@ -27,14 +27,14 @@ import {
   TrackList,
   useFetchServerQuery,
   useLazySearchQuery,
-  useUpdateTrackMutation
+  useUpdateTrackMutation,
 } from "store/api";
 import {
   loadTrack,
   trackGuild,
   trackPlayer,
   untrackGuild,
-  untrackPlayer
+  untrackPlayer,
 } from "store/track";
 
 const Track = () => {

--- a/dashboard/src/store/api.ts
+++ b/dashboard/src/store/api.ts
@@ -29,6 +29,7 @@ export interface Server {
     guilds: number;
     alliances: number;
   };
+  track: TrackList;
 }
 
 export interface Channel {
@@ -56,7 +57,6 @@ export interface Settings {
     pvpRanking: string;
     guildRanking: string;
   };
-  track: TrackList;
 }
 
 export interface TrackList {

--- a/server/migrations/1663130069008-split-track-collection.js
+++ b/server/migrations/1663130069008-split-track-collection.js
@@ -1,0 +1,36 @@
+const logger = require("../src/helpers/logger");
+const database = require("../src/ports/database");
+
+async function splitTrackingFromSettings() {
+  const settingsCollection = database.getCollection("settings");
+  const trackingCollection = database.getCollection("track");
+
+  const settings = await settingsCollection.find({});
+  let setting = await settings.next();
+  while (setting) {
+    if (setting.track) {
+      const { track, guild } = setting;
+      logger.verbose(
+        `Moving server ${guild} track containing ${track.players.length} players, ${track.guilds.length} guilds and ${track.alliances.length} alliances.`,
+      );
+
+      await trackingCollection.insertOne({ server: guild, ...track });
+      await settingsCollection.updateOne(
+        { _id: setting._id },
+        {
+          $unset: { track: "" },
+        },
+      );
+    }
+
+    setting = await settings.next();
+  }
+}
+
+async function run() {
+  await splitTrackingFromSettings();
+}
+
+module.exports = {
+  run,
+};

--- a/server/src/helpers/tracking.js
+++ b/server/src/helpers/tracking.js
@@ -1,10 +1,7 @@
 // This method checks if an event is tracked by a discord server
 // and flags it as a good event (killed is tracked) or bad event (victim is tracker)
 // and returns a copy of it or null if the event is not tracked at all
-function getTrackedEvent(event, settings) {
-  if (!settings.track) return;
-  const { players = [], guilds = [], alliances = [] } = settings.track;
-
+function getTrackedEvent(event, { players = [], guilds = [], alliances = [] }) {
   if (players.length === 0 && guilds.length === 0 && alliances.length === 0) {
     return null;
   }
@@ -37,10 +34,7 @@ function getTrackedEvent(event, settings) {
 
 // This method checks if a battle is tracked by a discord server
 // and returns the battle or null if the event is not tracked at all
-function getTrackedBattle(battle, settings) {
-  if (!settings.track) return;
-  const { players = [], guilds = [], alliances = [] } = settings.track;
-
+function getTrackedBattle(battle, { players = [], guilds = [], alliances = [] }) {
   if (players.length === 0 && guilds.length === 0 && alliances.length === 0) {
     return null;
   }

--- a/server/src/interfaces/api/controllers/servers.js
+++ b/server/src/interfaces/api/controllers/servers.js
@@ -1,6 +1,7 @@
 const serversService = require("../../../services/servers");
 const settingsService = require("../../../services/settings");
 const subscriptionService = require("../../../services/subscriptions");
+const trackService = require("../../../services/track");
 
 async function getServer(req, res) {
   const { serverId } = req.params;
@@ -44,8 +45,8 @@ async function setServerTrack(req, res) {
 
   const track = req.body;
 
-  const settings = await settingsService.setSettings(serverId, { track });
-  return res.send(settings.track);
+  const newTrack = await trackService.setTrack(serverId, { track });
+  return res.send(newTrack);
 }
 
 module.exports = {

--- a/server/src/interfaces/api/controllers/servers.js
+++ b/server/src/interfaces/api/controllers/servers.js
@@ -13,8 +13,11 @@ async function getServer(req, res) {
   const subscription = await subscriptionService.getSubscriptionByServerId(serverId);
   server.subscription = subscription;
 
-  const limits = await subscriptionService.getLimitsByServerId(serverId);
+  const limits = await trackService.getLimitsByServerId(serverId);
   server.limits = limits;
+
+  const track = await trackService.getTrack(serverId);
+  server.track = track;
 
   return res.send(server);
 }
@@ -44,8 +47,9 @@ async function setServerTrack(req, res) {
   if (!isOwner) return res.sendStatus(403);
 
   const track = req.body;
+  // TODO: Validate schema
 
-  const newTrack = await trackService.setTrack(serverId, { track });
+  const newTrack = await trackService.setTrack(serverId, track);
   return res.send(newTrack);
 }
 

--- a/server/src/interfaces/api/routes/servers.js
+++ b/server/src/interfaces/api/routes/servers.js
@@ -46,6 +46,9 @@ router.use(authenticated);
  *            alliances:
  *              type: number
  *              default: 1
+ *        track:
+ *          readOnly: true
+ *          $ref: '#/components/schemas/Track'
  *
  *    Channel:
  *      type: object
@@ -132,9 +135,6 @@ router.use(authenticated);
  *              type: string
  *              description: Patreon user id of the subscription owner
  *              example: "17225165"
- *        track:
- *          readOnly: true
- *          $ref: '#/components/schemas/Track'
  *
  *    Category:
  *      type: object

--- a/server/src/interfaces/bot/commands/help.js
+++ b/server/src/interfaces/bot/commands/help.js
@@ -9,9 +9,7 @@ const command = {
   description: getLocale().t("HELP.HELP"),
   type: InteractionType.Ping,
   default_permission: true,
-  handle: async (interaction, { lang }) => {
-    const t = getLocale(lang).t;
-
+  handle: async (interaction, { t }) => {
     let response = "```\n";
     if (process.env.npm_package_version) {
       response += t("HELP.VERSION", {

--- a/server/src/interfaces/bot/commands/index.js
+++ b/server/src/interfaces/bot/commands/index.js
@@ -6,6 +6,7 @@ const { getLocale } = require("../../../helpers/locale");
 
 const logger = require("../../../helpers/logger");
 const { getSettings } = require("../../../services/settings");
+const { getTrack } = require("../../../services/track");
 
 const rest = new REST({ version: "10" });
 let commands = [];
@@ -55,7 +56,8 @@ function getCommands() {
 async function handle(interaction) {
   const prefix = `[#${interaction.id}/${interaction.commandName}]`;
   const settings = await getSettings(interaction.guild.id);
-  const t = getLocale().t;
+  const track = await getTrack(interaction.guild.id);
+  const t = getLocale(settings.lang).t;
 
   try {
     if (!hasCommand(interaction.commandName)) throw new Error("COMMAND_NOT_FOUND");
@@ -70,7 +72,7 @@ async function handle(interaction) {
     });
 
     const command = commands.find((c) => c.name == interaction.commandName);
-    return await command.handle(interaction, settings);
+    return await command.handle(interaction, { settings, track, t });
   } catch (e) {
     logger.error(`${prefix} Error in interaction:`, e);
     const reply = (!interaction.deferred && !interaction.replied ? interaction.reply : interaction.editReply).bind(

--- a/server/src/interfaces/bot/commands/list.js
+++ b/server/src/interfaces/bot/commands/list.js
@@ -7,9 +7,9 @@ const command = {
   description: getLocale().t("HELP.LIST"),
   type: InteractionType.Ping,
   default_member_permissions: "0",
-  handle: async (interaction, { track, lang }) => {
+  handle: async (interaction, { settings, track }) => {
     await interaction.reply({
-      ...embedTrackList(track, { locale: lang }),
+      ...embedTrackList(track, { locale: settings.lang }),
       ephemeral: true,
     });
   },

--- a/server/src/interfaces/bot/commands/ranking.js
+++ b/server/src/interfaces/bot/commands/ranking.js
@@ -32,7 +32,7 @@ const command = {
   type: InteractionType.Ping,
   default_permission: true,
   options,
-  handle: async (interaction, settings) => {
+  handle: async (interaction, { settings, track, t }) => {
     const rankingType = interaction.options.getString("ranking");
 
     const rankings = {
@@ -43,7 +43,9 @@ const command = {
       },
       guildRanking: async () => {
         await interaction.deferReply({ ephemeral: false });
-        for (const trackGuild of settings.track.guilds) {
+        if (!track.guilds || track.guilds.length === 0)
+          return await interaction.editReply({ content: "No tracked guilds to display rankings.", ephemeral: true });
+        for (const trackGuild of track.guilds) {
           const albionGuild = await getGuild(trackGuild.id);
           if (!albionGuild) await interaction.followUp(t("RANKING.NO_DATA", { guild: trackGuild.name }));
           else await interaction.followUp(embedGuildRanking(albionGuild, { locale: settings.lang }));

--- a/server/src/interfaces/bot/commands/settings.js
+++ b/server/src/interfaces/bot/commands/settings.js
@@ -149,9 +149,7 @@ const command = {
   type: InteractionType.Ping,
   default_member_permissions: "0",
   options: [kills, battles, rankings, lang],
-  handle: async (interaction, settings) => {
-    const t = getLocale(settings.lang).t;
-
+  handle: async (interaction, { settings, t }) => {
     const reply = async (content, ephemeral = true) => await interaction.reply({ content, ephemeral });
     const editReply = async (content, ephemeral = true) => await interaction.editReply({ content, ephemeral });
 

--- a/server/src/interfaces/bot/commands/subscription.js
+++ b/server/src/interfaces/bot/commands/subscription.js
@@ -10,9 +10,7 @@ const command = {
   description: t("HELP.SUBSCRIPTION"),
   type: InteractionType.Ping,
   default_member_permissions: "0",
-  handle: async (interaction, settings) => {
-    const { guild, lang } = settings;
-    const t = getLocale(lang).t;
+  handle: async (interaction, { t }) => {
     const ephemeral = true;
 
     if (!isSubscriptionsEnabled())
@@ -21,7 +19,7 @@ const command = {
         ephemeral,
       });
 
-    const subscription = await getSubscriptionByServerId(guild);
+    const subscription = await getSubscriptionByServerId(interaction.guild.id);
     if (!subscription || !subscription.expires)
       return await interaction.reply({
         content: t("SUBSCRIPTION.STATUS.INACTIVE"),

--- a/server/src/interfaces/bot/commands/track.js
+++ b/server/src/interfaces/bot/commands/track.js
@@ -68,13 +68,10 @@ const command = {
         const alliance = await getAlliance(value);
         if (!alliance) return addContent(t("TRACK.NOT_FOUND"));
 
-        track.alliances.push({
-          id: alliance.AllianceId,
-          name: alliance.AllianceTag,
-        });
+        track.alliances.push(alliance);
 
         await setTrack(interaction.guild.id, track);
-        return addContent(t("TRACK.ALLIANCES.TRACKED", { name: alliance.AllianceTag }));
+        return addContent(t("TRACK.ALLIANCES.TRACKED", { name: alliance.name }));
       } else {
         const equalsCaseInsensitive = (a, b) => a && a.localeCompare(b, undefined, { sensitivity: "base" }) === 0;
 
@@ -87,10 +84,7 @@ const command = {
         const entity = searchResults[type].find((searchEntity) => equalsCaseInsensitive(searchEntity.name, value));
         if (!entity) return addContent(t("TRACK.NOT_FOUND"));
 
-        track[type].push({
-          id: entity.id,
-          name: entity.name,
-        });
+        track[type].push(entity);
 
         await setTrack(interaction.guild.id, track);
         return addContent(t(`TRACK.${type.toUpperCase()}.TRACKED`, { name: entity.name }));

--- a/server/src/interfaces/bot/commands/track.js
+++ b/server/src/interfaces/bot/commands/track.js
@@ -2,8 +2,7 @@ const { InteractionType } = require("discord-api-types/v10");
 const { String } = require("discord-api-types/v10").ApplicationCommandOptionType;
 const { getLocale } = require("../../../helpers/locale");
 const { getAlliance, search } = require("../../../services/search");
-const { setSettings } = require("../../../services/settings");
-const { getLimitsByServerId } = require("../../../services/subscriptions");
+const { getLimitsByServerId, setTrack } = require("../../../services/track");
 
 const t = getLocale().t;
 
@@ -31,9 +30,8 @@ const command = {
   type: InteractionType.Ping,
   default_member_permissions: "0",
   options,
-  handle: async (interaction, settings) => {
-    const t = getLocale(settings.lang).t;
-    const limits = await getLimitsByServerId(settings.server);
+  handle: async (interaction, { track, t }) => {
+    const limits = await getLimitsByServerId(interaction.guild.id);
 
     const playerName = interaction.options.getString("player");
     const guildName = interaction.options.getString("guild");
@@ -53,34 +51,34 @@ const command = {
       content += msg + "\n";
     };
 
-    const track = async (type, value, limit = 5) => {
+    const addTrack = async (type, value, limit = 5) => {
       if (limit == 0) {
         const trackType = t(`TRACK.${type.toUpperCase()}.DESCRIPTION`).toLowerCase();
         return addContent(t("TRACK.TRACKING_DISABLED", { type: trackType }));
       }
 
-      if (!settings.track) settings.track = {};
-      if (!settings.track[type]) settings.track[type] = [];
+      if (!track) track = {};
+      if (!track[type]) track[type] = [];
 
-      if (settings.track[type].length >= limit) return addContent(t("TRACK.LIMIT_REACHED", { limit }));
+      if (track[type].length >= limit) return addContent(t("TRACK.LIMIT_REACHED", { limit }));
 
       if (type == "alliances") {
-        if (settings.track.alliances.some((a) => a.id === value)) return addContent(t("TRACK.ALREADY_TRACKED"));
+        if (track.alliances.some((a) => a.id === value)) return addContent(t("TRACK.ALREADY_TRACKED"));
 
         const alliance = await getAlliance(value);
         if (!alliance) return addContent(t("TRACK.NOT_FOUND"));
 
-        settings.track.alliances.push({
+        track.alliances.push({
           id: alliance.AllianceId,
           name: alliance.AllianceTag,
         });
 
-        await setSettings(interaction.guild.id, settings);
+        await setTrack(interaction.guild.id, track);
         return addContent(t("TRACK.ALLIANCES.TRACKED", { name: alliance.AllianceTag }));
       } else {
         const equalsCaseInsensitive = (a, b) => a && a.localeCompare(b, undefined, { sensitivity: "base" }) === 0;
 
-        if (settings.track[type].some((trackEntity) => equalsCaseInsensitive(trackEntity.name, value)))
+        if (track[type].some((trackEntity) => equalsCaseInsensitive(trackEntity.name, value)))
           return addContent(t("TRACK.ALREADY_TRACKED"));
 
         const searchResults = await search(value);
@@ -89,19 +87,19 @@ const command = {
         const entity = searchResults[type].find((searchEntity) => equalsCaseInsensitive(searchEntity.name, value));
         if (!entity) return addContent(t("TRACK.NOT_FOUND"));
 
-        settings.track[type].push({
+        track[type].push({
           id: entity.id,
           name: entity.name,
         });
 
-        await setSettings(interaction.guild.id, settings);
+        await setTrack(interaction.guild.id, track);
         return addContent(t(`TRACK.${type.toUpperCase()}.TRACKED`, { name: entity.name }));
       }
     };
 
-    if (allianceId) await track("alliances", allianceId, limits.alliances);
-    if (playerName) await track("players", playerName, limits.players);
-    if (guildName) await track("guilds", guildName, limits.guilds);
+    if (allianceId) await addTrack("alliances", allianceId, limits.alliances);
+    if (playerName) await addTrack("players", playerName, limits.players);
+    if (guildName) await addTrack("guilds", guildName, limits.guilds);
 
     return await interaction.editReply({ content, ephemeral: true });
   },

--- a/server/src/interfaces/bot/commands/untrack.js
+++ b/server/src/interfaces/bot/commands/untrack.js
@@ -52,13 +52,8 @@ const command = {
       if (!track) track = {};
       if (!track[type]) track[type] = [];
 
-      let entity;
-      if (type == "alliances") {
-        entity = track.alliances.find((a) => a.id === value);
-      } else {
-        const equalsCaseInsensitive = (a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }) === 0;
-        entity = track[type].find((trackEntity) => equalsCaseInsensitive(trackEntity.name, value));
-      }
+      const equalsCaseInsensitive = (a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }) === 0;
+      const entity = track[type].find((trackEntity) => equalsCaseInsensitive(trackEntity.name, value));
 
       if (!entity) return addContent(t("TRACK.NOT_FOUND"));
 

--- a/server/src/interfaces/bot/commands/untrack.js
+++ b/server/src/interfaces/bot/commands/untrack.js
@@ -1,7 +1,7 @@
 const { InteractionType } = require("discord-api-types/v10");
 const { String } = require("discord-api-types/v10").ApplicationCommandOptionType;
 const { getLocale } = require("../../../helpers/locale");
-const { setSettings } = require("../../../services/settings");
+const { setTrack } = require("../../../services/track");
 
 const t = getLocale().t;
 
@@ -29,9 +29,7 @@ const command = {
   type: InteractionType.Ping,
   default_member_permissions: "0",
   options,
-  handle: async (interaction, settings) => {
-    const t = getLocale(settings.lang).t;
-
+  handle: async (interaction, { track, t }) => {
     const playerName = interaction.options.getString("player");
     const guildName = interaction.options.getString("guild");
     const allianceId = interaction.options.getString("alliance");
@@ -51,22 +49,22 @@ const command = {
     };
 
     const untrack = async (type, value) => {
-      if (!settings.track) settings.track = {};
-      if (!settings.track[type]) settings.track[type] = [];
+      if (!track) track = {};
+      if (!track[type]) track[type] = [];
 
       let entity;
       if (type == "alliances") {
-        entity = settings.track.alliances.find((a) => a.id === value);
+        entity = track.alliances.find((a) => a.id === value);
       } else {
         const equalsCaseInsensitive = (a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }) === 0;
-        entity = settings.track[type].find((trackEntity) => equalsCaseInsensitive(trackEntity.name, value));
+        entity = track[type].find((trackEntity) => equalsCaseInsensitive(trackEntity.name, value));
       }
 
       if (!entity) return addContent(t("TRACK.NOT_FOUND"));
 
-      settings.track[type] = settings.track[type].filter((e) => e != entity);
+      track[type] = track[type].filter((e) => e != entity);
 
-      await setSettings(interaction.guild.id, settings);
+      await setTrack(interaction.guild.id, track);
       return addContent(t(`TRACK.${type.toUpperCase()}.UNTRACKED`, { name: entity.name }));
     };
 

--- a/server/src/interfaces/bot/controllers/battles.js
+++ b/server/src/interfaces/bot/controllers/battles.js
@@ -2,7 +2,7 @@ const logger = require("../../../helpers/logger");
 const { getTrackedBattle } = require("../../../helpers/tracking");
 
 const { subscribeBattles } = require("../../../services/battles");
-const { getSettingsByGuild } = require("../../../services/settings");
+const { getSettingsForServer } = require("../../../services/settings");
 const { getTrackForServer } = require("../../../services/track");
 
 const { embedBattle } = require("../../../helpers/embeds");
@@ -16,7 +16,7 @@ async function subscribe(client) {
     logger.debug(`Received battle: ${battle.id}`);
 
     try {
-      const settingsByGuild = await getSettingsByGuild(client.guilds.cache);
+      const settingsByGuild = await getSettingsForServer(client.guilds.cache);
       const trackByGuild = await getTrackForServer(client.guilds.cache);
 
       for (const guild of client.guilds.cache.values()) {

--- a/server/src/interfaces/bot/controllers/battles.js
+++ b/server/src/interfaces/bot/controllers/battles.js
@@ -3,6 +3,7 @@ const { getTrackedBattle } = require("../../../helpers/tracking");
 
 const { subscribeBattles } = require("../../../services/battles");
 const { getSettingsByGuild } = require("../../../services/settings");
+const { getTrackForServer } = require("../../../services/track");
 
 const { embedBattle } = require("../../../helpers/embeds");
 
@@ -16,12 +17,13 @@ async function subscribe(client) {
 
     try {
       const settingsByGuild = await getSettingsByGuild(client.guilds.cache);
+      const trackByGuild = await getTrackForServer(client.guilds.cache);
 
       for (const guild of client.guilds.cache.values()) {
         if (!settingsByGuild[guild.id]) continue;
         guild.settings = settingsByGuild[guild.id];
 
-        const guildBattle = getTrackedBattle(battle, guild.settings);
+        const guildBattle = getTrackedBattle(battle, trackByGuild[guild.id]);
         if (!guildBattle) continue;
 
         const { enabled, channel } = guild.settings.battles;

--- a/server/src/interfaces/bot/controllers/events.js
+++ b/server/src/interfaces/bot/controllers/events.js
@@ -5,6 +5,7 @@ const { subscribeEvents } = require("../../../services/events");
 const { generateEventImage, generateInventoryImage } = require("../../../services/images");
 const { getSettingsByGuild, REPORT_MODES } = require("../../../services/settings");
 const { addRankingKill } = require("../../../services/rankings");
+const { getTrackForServer } = require("../../../services/track");
 
 const { embedEvent, embedEventImage, embedEventInventoryImage } = require("../../../helpers/embeds");
 
@@ -19,12 +20,13 @@ async function subscribe(client) {
     try {
       // TODO: This chunk repeat a lot. Find a way to componentize
       const settingsByGuild = await getSettingsByGuild(client.guilds.cache);
+      const trackByGuild = await getTrackForServer(client.guilds.cache);
 
       for (const guild of client.guilds.cache.values()) {
         if (!settingsByGuild[guild.id]) continue;
         guild.settings = settingsByGuild[guild.id];
 
-        const guildEvent = getTrackedEvent(event, guild.settings);
+        const guildEvent = getTrackedEvent(event, trackByGuild[guild.id]);
         if (!guildEvent) continue;
         addRankingKill(guild.id, guildEvent, guild.settings);
 

--- a/server/src/interfaces/bot/controllers/events.js
+++ b/server/src/interfaces/bot/controllers/events.js
@@ -3,7 +3,7 @@ const { getTrackedEvent } = require("../../../helpers/tracking");
 
 const { subscribeEvents } = require("../../../services/events");
 const { generateEventImage, generateInventoryImage } = require("../../../services/images");
-const { getSettingsByGuild, REPORT_MODES } = require("../../../services/settings");
+const { getSettingsForServer, REPORT_MODES } = require("../../../services/settings");
 const { addRankingKill } = require("../../../services/rankings");
 const { getTrackForServer } = require("../../../services/track");
 
@@ -19,7 +19,7 @@ async function subscribe(client) {
 
     try {
       // TODO: This chunk repeat a lot. Find a way to componentize
-      const settingsByGuild = await getSettingsByGuild(client.guilds.cache);
+      const settingsByGuild = await getSettingsForServer(client.guilds.cache);
       const trackByGuild = await getTrackForServer(client.guilds.cache);
 
       for (const guild of client.guilds.cache.values()) {

--- a/server/src/interfaces/bot/controllers/guilds.js
+++ b/server/src/interfaces/bot/controllers/guilds.js
@@ -6,7 +6,7 @@ const { embedGuildRanking } = require("../../../helpers/embeds");
 const logger = require("../../../helpers/logger");
 
 const { getAllGuilds, updateGuild } = require("../../../services/guilds");
-const { getSettingsByGuild } = require("../../../services/settings");
+const { getSettingsForServer } = require("../../../services/settings");
 const { getTrackForServer } = require("../../../services/track");
 
 async function updateGuilds(client) {
@@ -38,7 +38,7 @@ async function displayRankings(client, { setting }) {
 
   logger.info(`[#${shardId}] Sending guild ranking on '${setting}' setting to all servers.`);
 
-  const settingsByGuild = await getSettingsByGuild(client.guilds.cache);
+  const settingsByGuild = await getSettingsForServer(client.guilds.cache);
   const trackForServer = await getTrackForServer(client.guilds.cache);
   const albionGuilds = await getAllGuilds();
 

--- a/server/src/interfaces/bot/controllers/guilds.js
+++ b/server/src/interfaces/bot/controllers/guilds.js
@@ -1,26 +1,27 @@
 const moment = require("moment");
 
-const logger = require("../../../helpers/logger");
-const { getSettingsByGuild } = require("../../../services/settings");
-const { getAllGuilds, updateGuild } = require("../../../services/guilds");
-const { embedGuildRanking } = require("../../../helpers/embeds");
-
 const { sendNotification } = require("./notifications");
+
+const { embedGuildRanking } = require("../../../helpers/embeds");
+const logger = require("../../../helpers/logger");
+
+const { getAllGuilds, updateGuild } = require("../../../services/guilds");
+const { getSettingsByGuild } = require("../../../services/settings");
+const { getTrackForServer } = require("../../../services/track");
 
 async function updateGuilds(client) {
   const { shardId } = client;
 
   logger.verbose(`[#${shardId}] Updating albion guild data`);
 
-  const settingsByGuild = await getSettingsByGuild(client.guilds.cache);
+  const trackForServer = await getTrackForServer(client.guilds.cache);
   const albionGuilds = await getAllGuilds();
 
   for (const guild of client.guilds.cache.values()) {
-    if (!settingsByGuild[guild.id]) continue;
+    if (!trackForServer[guild.id]) continue;
+    const track = trackForServer[guild.id];
 
-    guild.settings = settingsByGuild[guild.id];
-
-    for (const trackedGuild of guild.settings.track.guilds) {
+    for (const trackedGuild of track.guilds) {
       const albionGuild = albionGuilds[trackedGuild.id];
       if (!!albionGuild && moment().diff(moment(albionGuild.updatedAt), "days") < 1) continue;
 
@@ -38,25 +39,26 @@ async function displayRankings(client, { setting }) {
   logger.info(`[#${shardId}] Sending guild ranking on '${setting}' setting to all servers.`);
 
   const settingsByGuild = await getSettingsByGuild(client.guilds.cache);
+  const trackForServer = await getTrackForServer(client.guilds.cache);
   const albionGuilds = await getAllGuilds();
 
   for (const guild of client.guilds.cache.values()) {
-    if (!settingsByGuild[guild.id]) continue;
+    if (!trackForServer[guild.id] || !settingsByGuild[guild.id]) continue;
+    const settings = settingsByGuild[guild.id];
+    const track = trackForServer[guild.id];
 
-    guild.settings = settingsByGuild[guild.id];
-
-    const { enabled, channel, guildRanking } = guild.settings.rankings;
+    const { enabled, channel, guildRanking } = settings.rankings;
     if (!enabled || !channel) continue;
     if (guildRanking != setting) continue;
 
-    for (const trackedGuild of guild.settings.track.guilds) {
+    for (const trackedGuild of track.guilds) {
       const trackedGuildData = albionGuilds[trackedGuild.id];
       if (!trackedGuildData || !trackedGuildData.rankings) {
         logger.verbose(`[#${shardId}] No data available for guild "${trackedGuild.name}"`);
         continue;
       }
 
-      await sendNotification(client, channel, embedGuildRanking(trackedGuildData, { locale: guild.settings.lang }));
+      await sendNotification(client, channel, embedGuildRanking(trackedGuildData, { locale: settings.lang }));
     }
   }
 

--- a/server/src/interfaces/bot/controllers/rankings.js
+++ b/server/src/interfaces/bot/controllers/rankings.js
@@ -1,6 +1,6 @@
 const logger = require("../../../helpers/logger");
 const { getRanking, deleteRankings } = require("../../../services/rankings");
-const { getSettingsByGuild } = require("../../../services/settings");
+const { getSettingsForServer } = require("../../../services/settings");
 
 const { embedPvpRanking } = require("../../../helpers/embeds");
 
@@ -11,7 +11,7 @@ async function displayRankings(client, { setting }) {
 
   logger.info(`[#${shardId}] Sending pvp ranking on '${setting}' setting to all servers.`);
 
-  const settingsByGuild = await getSettingsByGuild(client.guilds.cache);
+  const settingsByGuild = await getSettingsForServer(client.guilds.cache);
 
   for (const guild of client.guilds.cache.values()) {
     if (!settingsByGuild[guild.id]) continue;

--- a/server/src/ports/database.js
+++ b/server/src/ports/database.js
@@ -61,6 +61,12 @@ async function findOne(collectionName, query) {
   return returnObjectId(document);
 }
 
+async function updateOne(collectionName, filter, update, options) {
+  const collection = getCollection(collectionName);
+  const document = await collection.updateOne(convertObjectId(filter), update, options);
+  return returnObjectId(document);
+}
+
 module.exports = {
   cleanup,
   dropColection,
@@ -68,4 +74,5 @@ module.exports = {
   findOne,
   getCollection,
   init,
+  updateOne,
 };

--- a/server/src/services/settings.js
+++ b/server/src/services/settings.js
@@ -30,21 +30,21 @@ async function getSettings(guild) {
   return (await collection.findOne({ guild })) || DEFAULT_SETTINGS;
 }
 
-async function getSettingsByGuild(guilds) {
+async function getSettingsForServer(servers) {
   const collection = getCollection(SETTINGS_COLLECTION);
 
-  const settingsByGuild = {};
-  guilds.forEach((guild) => {
-    settingsByGuild[guild] = DEFAULT_SETTINGS;
+  const settingsForServer = {};
+  servers.forEach((server) => {
+    settingsForServer[server.id] = DEFAULT_SETTINGS;
   });
 
   await collection.find({}).forEach((settings) => {
     // TODO: Trim track list if subscription is expired
     // Better to do when Track list gets refactored
-    settingsByGuild[settings.guild] = settings;
+    settingsForServer[settings.guild] = settings;
   });
 
-  return settingsByGuild;
+  return settingsForServer;
 }
 
 async function getAllSettings() {
@@ -79,7 +79,7 @@ module.exports = {
   REPORT_MODES,
   DEFAULT_SETTINGS,
   getSettings,
-  getSettingsByGuild,
+  getSettingsForServer,
   getAllSettings,
   setSettings,
   deleteSettings,

--- a/server/src/services/settings.js
+++ b/server/src/services/settings.js
@@ -23,11 +23,6 @@ const DEFAULT_SETTINGS = {
     pvpRanking: "daily",
     guildRanking: "daily",
   },
-  track: {
-    players: [],
-    guilds: [],
-    alliances: [],
-  },
 };
 
 async function getSettings(guild) {

--- a/server/src/services/subscriptions.js
+++ b/server/src/services/subscriptions.js
@@ -1,9 +1,7 @@
 const moment = require("moment");
 const stripe = require("../ports/stripe");
 const { getCollection, find, findOne } = require("../ports/database");
-const { getNumber } = require("../helpers/utils");
 
-const { MAX_PLAYERS, MAX_GUILDS, MAX_ALLIANCES, SUB_MAX_PLAYERS, SUB_MAX_GUILDS, SUB_MAX_ALLIANCES } = process.env;
 const SUBSCRIPTIONS_MODE = Boolean(process.env.SUBSCRIPTIONS_MODE);
 const SUBSCRIPTIONS_COLLECTION = "subscriptions";
 
@@ -71,24 +69,6 @@ async function getStripeSubscription(id) {
   return await stripe.getSubscription(id);
 }
 
-async function getLimitsByServerId(server) {
-  let players = getNumber(MAX_PLAYERS, 10);
-  let guilds = getNumber(MAX_GUILDS, 1);
-  let alliances = getNumber(MAX_ALLIANCES, 1);
-
-  if (isSubscriptionsEnabled() && (await hasSubscriptionByServerId(server))) {
-    players = getNumber(SUB_MAX_PLAYERS, players);
-    guilds = getNumber(SUB_MAX_GUILDS, guilds);
-    alliances = getNumber(SUB_MAX_ALLIANCES, alliances);
-  }
-
-  return {
-    players,
-    guilds,
-    alliances,
-  };
-}
-
 async function hasSubscriptionByServerId(server) {
   if (!isSubscriptionsEnabled()) return true;
   const subscription = await findOne(SUBSCRIPTIONS_COLLECTION, { server });
@@ -124,7 +104,6 @@ module.exports = {
   fetchSubscriptionPrices,
   findSubscriptionsByServerId,
   getBuySubscription,
-  getLimitsByServerId,
   getStripeSubscription,
   getSubscriptionByCheckoutId,
   getSubscriptionById,

--- a/server/src/services/track.js
+++ b/server/src/services/track.js
@@ -12,11 +12,15 @@ const DEFAULT_TRACK = {
 };
 
 async function getTrack(server) {
-  return await findOne(TRACK_COLLECTION, { server });
+  const track = await findOne(TRACK_COLLECTION, { server });
+  return {
+    ...DEFAULT_TRACK,
+    ...track,
+  };
 }
 
 async function setTrack(server, track) {
-  await updateOne({ server }, { $set: track }, { upsert: true });
+  await updateOne(TRACK_COLLECTION, { server }, { $set: track }, { upsert: true });
   return await getTrack(server);
 }
 
@@ -39,7 +43,6 @@ async function getLimitsByServerId(server) {
 }
 
 module.exports = {
-  DEFAULT_TRACK,
   getLimitsByServerId,
   getTrack,
   setTrack,

--- a/server/src/services/track.js
+++ b/server/src/services/track.js
@@ -22,13 +22,13 @@ async function getTrack(server) {
 async function getTrackForServer(servers) {
   const trackForServer = {};
   servers.forEach((server) => {
-    trackForServer[server] = DEFAULT_TRACK;
+    trackForServer[server.id] = DEFAULT_TRACK;
   });
 
-  (await find(TRACK_COLLECTION, {})).forEach((settings) => {
+  (await find(TRACK_COLLECTION, {})).forEach((track) => {
     // TODO: Trim track list if subscription is expired
     // Better to do when Track list gets refactored
-    trackForServer[settings.guild] = settings;
+    trackForServer[track.server] = track;
   });
 
   return trackForServer;

--- a/server/src/services/track.js
+++ b/server/src/services/track.js
@@ -25,7 +25,7 @@ async function getTrackForServer(servers) {
     trackForServer[server] = DEFAULT_TRACK;
   });
 
-  await find(TRACK_COLLECTION, {}).forEach((settings) => {
+  (await find(TRACK_COLLECTION, {})).forEach((settings) => {
     // TODO: Trim track list if subscription is expired
     // Better to do when Track list gets refactored
     trackForServer[settings.guild] = settings;

--- a/server/src/services/track.js
+++ b/server/src/services/track.js
@@ -1,0 +1,46 @@
+const { findOne, updateOne } = require("../ports/database");
+const { getNumber } = require("../helpers/utils");
+const { hasSubscriptionByServerId } = require("./subscriptions");
+
+const { MAX_PLAYERS, MAX_GUILDS, MAX_ALLIANCES, SUB_MAX_PLAYERS, SUB_MAX_GUILDS, SUB_MAX_ALLIANCES } = process.env;
+const TRACK_COLLECTION = "track";
+
+const DEFAULT_TRACK = {
+  players: [],
+  guilds: [],
+  alliances: [],
+};
+
+async function getTrack(server) {
+  return await findOne(TRACK_COLLECTION, { server });
+}
+
+async function setTrack(server, track) {
+  await updateOne({ server }, { $set: track }, { upsert: true });
+  return await getTrack(server);
+}
+
+async function getLimitsByServerId(server) {
+  let players = getNumber(MAX_PLAYERS, 10);
+  let guilds = getNumber(MAX_GUILDS, 1);
+  let alliances = getNumber(MAX_ALLIANCES, 1);
+
+  if (await hasSubscriptionByServerId(server)) {
+    players = getNumber(SUB_MAX_PLAYERS, players);
+    guilds = getNumber(SUB_MAX_GUILDS, guilds);
+    alliances = getNumber(SUB_MAX_ALLIANCES, alliances);
+  }
+
+  return {
+    players,
+    guilds,
+    alliances,
+  };
+}
+
+module.exports = {
+  DEFAULT_TRACK,
+  getLimitsByServerId,
+  getTrack,
+  setTrack,
+};

--- a/server/src/services/track.js
+++ b/server/src/services/track.js
@@ -1,4 +1,4 @@
-const { findOne, updateOne } = require("../ports/database");
+const { find, findOne, updateOne } = require("../ports/database");
 const { getNumber } = require("../helpers/utils");
 const { hasSubscriptionByServerId } = require("./subscriptions");
 
@@ -17,6 +17,21 @@ async function getTrack(server) {
     ...DEFAULT_TRACK,
     ...track,
   };
+}
+
+async function getTrackForServer(servers) {
+  const trackForServer = {};
+  servers.forEach((server) => {
+    trackForServer[server] = DEFAULT_TRACK;
+  });
+
+  await find(TRACK_COLLECTION, {}).forEach((settings) => {
+    // TODO: Trim track list if subscription is expired
+    // Better to do when Track list gets refactored
+    trackForServer[settings.guild] = settings;
+  });
+
+  return trackForServer;
 }
 
 async function setTrack(server, track) {
@@ -45,5 +60,6 @@ async function getLimitsByServerId(server) {
 module.exports = {
   getLimitsByServerId,
   getTrack,
+  getTrackForServer,
   setTrack,
 };


### PR DESCRIPTION

# Description

- Add migration to split track collection
- Add updateOne function to database port
- Move track to its own service
- Update api to the new track service
- Update track helper
- Refactor bot commands
- fixup! Update track helper
- Refactor guild ranking display for the track collection
- Refactor dashboard track page
- Refactor api
- Rename getXByY to getXForY for group aggregation methods

Fixes #135

# PR Checklist

- [ ] I tested my changes locally
- [ ] I added new tests (if applicabble)
- [ ] I guaranteed that the coverage will not to red threshold
- [ ] I updated the Documentation accordingly
