### PR TITLE
Enable server admin operation in dashboard

### DIFF
--- a/dashboard/src/components/SubscriptionAssignModal/index.tsx
+++ b/dashboard/src/components/SubscriptionAssignModal/index.tsx
@@ -4,10 +4,7 @@ import Toast from "components/Toast";
 import { useState } from "react";
 import { Alert, Button, Col, Modal, Row } from "react-bootstrap";
 import { Link, Navigate } from "react-router-dom";
-import {
-  useAssignSubscriptionMutation,
-  useFetchUserServersQuery,
-} from "store/api";
+import { useAssignSubscriptionMutation, useFetchServersQuery } from "store/api";
 
 interface SubscriptionAssignModalProps {
   checkoutId?: string;
@@ -23,12 +20,11 @@ const SubscriptionAssignModal = ({
   onClose,
 }: SubscriptionAssignModalProps) => {
   const [show, setShow] = useState(true);
-  const servers = useFetchUserServersQuery();
+  const servers = useFetchServersQuery();
   const [dispatchAssignSubscription, assignSubscription] =
     useAssignSubscriptionMutation();
 
   if (assignSubscription.isSuccess && assignSubscription.data) {
-    console.log(assignSubscription.data);
     return (
       <Navigate
         to={`/dashboard/${assignSubscription.data.server}/subscription`}

--- a/dashboard/src/pages/Dashboard/index.tsx
+++ b/dashboard/src/pages/Dashboard/index.tsx
@@ -3,13 +3,13 @@ import ServerCard from "components/ServerCard";
 import { getServerInviteUrl } from "helpers/discord";
 import { Button, Col, Container, Row } from "react-bootstrap";
 import { Link } from "react-router-dom";
-import { ServerPartial, useFetchUserServersQuery } from "store/api";
+import { ServerPartial, useFetchServersQuery } from "store/api";
 import DashboardStyles from "./styles";
 
 const Dashboard = () => {
-  const userServers = useFetchUserServersQuery();
+  const servers = useFetchServersQuery();
 
-  if (userServers.isFetching) {
+  if (servers.isFetching) {
     return (
       <Loader width={500} height={500}>
         <rect x="160" y="15" rx="0" ry="0" width="210" height="20" />
@@ -33,7 +33,7 @@ const Dashboard = () => {
       const invitePopupTick = setInterval(function () {
         if (invitePopup.closed) {
           clearInterval(invitePopupTick);
-          userServers.refetch();
+          servers.refetch();
         }
       }, 1000);
     } else {
@@ -41,7 +41,7 @@ const Dashboard = () => {
     }
   };
 
-  const renderUserServer = (server: ServerPartial) => {
+  const renderServer = (server: ServerPartial) => {
     return (
       <Col sm={6} lg={4} key={server.id}>
         <ServerCard server={server}>
@@ -71,7 +71,7 @@ const Dashboard = () => {
       </div>
       <Container fluid className="pt-4">
         <Row className="g-4">
-          {userServers.data && userServers.data.map(renderUserServer)}
+          {servers.data && servers.data.map(renderServer)}
         </Row>
       </Container>
     </DashboardStyles>

--- a/dashboard/src/pages/Premium/index.tsx
+++ b/dashboard/src/pages/Premium/index.tsx
@@ -12,7 +12,7 @@ import { isSubscriptionActiveAndUnassiged } from "helpers/subscriptions";
 import { getCurrency } from "helpers/utils";
 import { useState } from "react";
 import { Alert, Button, Card, Col, ListGroup, Row } from "react-bootstrap";
-import { Link, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import {
   SubscriptionPrice,
   useBuySubscriptionMutation,
@@ -137,22 +137,15 @@ const Premium = () => {
                   </div>
                 </div>
                 <div className="actions">
-                  {subscription.server && (
-                    <Link to={`/dashboard/${subscription.server}/subscription`}>
-                      <Button variant="secondary">Dashboard</Button>
-                    </Link>
-                  )}
-                  {!subscription.server && (
-                    <Button
-                      variant="primary"
-                      onClick={() => setSubscriptionAssignId(subscription.id)}
-                    >
-                      Assign
-                    </Button>
-                  )}
+                  <Button
+                    variant="primary"
+                    onClick={() => setSubscriptionAssignId(subscription.id)}
+                  >
+                    {subscription.server ? "Transfer" : "Assign"}
+                  </Button>
                   {subscription.stripe?.customer && (
                     <Button
-                      variant="primary"
+                      variant="danger"
                       onClick={() => {
                         if (subscription.stripe?.customer)
                           dispatchManageSubscription(
@@ -160,7 +153,7 @@ const Premium = () => {
                           );
                       }}
                     >
-                      Manage
+                      Cancel
                     </Button>
                   )}
                 </div>

--- a/dashboard/src/pages/Subscription/index.tsx
+++ b/dashboard/src/pages/Subscription/index.tsx
@@ -33,8 +33,7 @@ const SubscriptionPage = () => {
           ) : (
             <div>
               This server doesn't have an active subscription. Please, go to{" "}
-              <Link to="/dashboard">Premium</Link> page to assign a
-              subscription.
+              <Link to="/premium">Premium</Link> page to assign a subscription.
             </div>
           )}
         </Alert>

--- a/dashboard/src/store/api.ts
+++ b/dashboard/src/store/api.ts
@@ -18,10 +18,7 @@ export interface ServerPartial {
   bot: boolean;
 }
 
-export interface Server {
-  id: string;
-  name: string;
-  icon: string;
+export interface Server extends ServerPartial {
   channels: Channel[];
   settings: Settings;
   limits: {
@@ -167,8 +164,8 @@ export const apiSlice = createApi({
         query: () => `/users/me`,
         providesTags: ["User"],
       }),
-      fetchUserServers: builder.query<ServerPartial[], void>({
-        query: () => `/users/me/servers`,
+      fetchServers: builder.query<ServerPartial[], void>({
+        query: () => `/servers`,
       }),
       fetchServer: builder.query<Server, string>({
         query: (serverId) => `/servers/${serverId}`,
@@ -210,9 +207,9 @@ export const {
   useBuySubscriptionMutation,
   useFetchPricesQuery,
   useFetchServerQuery,
+  useFetchServersQuery,
   useFetchSubscriptionsQuery,
   useFetchUserQuery,
-  useFetchUserServersQuery,
   useLazyFetchUserQuery,
   useLazySearchQuery,
   useLogoutMutation,

--- a/server/src/assets/locales/en.json
+++ b/server/src/assets/locales/en.json
@@ -54,7 +54,6 @@
     "NO_DATA_SHORT": "No data available"
   },
   "HELP": {
-    "VERSION": "Albion Killbot v{{ version }}",
     "HELP": "Show bot command list.",
     "CHANNEL": "Sets the channel to send notifications.",
     "LANGUAGE": "Set bot language.",
@@ -68,7 +67,12 @@
     "RANKING": "Display rankings.",
     "SUBSCRIPTION": "Check or activate your subscription.",
     "PREFIX": "Change bot prefix.",
-    "SETTINGS": "Change settings for your server."
+    "SETTINGS": "Change settings for your server.",
+    "VERSION": "Check bot version."
+  },
+  "VERSION": {
+    "PACKAGE_VERSION": "Albion Killbot v{{ version }}",
+    "VERSION_NOT_FOUND": "Unable to retrieve bot version."
   },
   "CHANNEL": {
     "NO_CHANNEL": "Please input a channel for notifications.",

--- a/server/src/assets/locales/es.json
+++ b/server/src/assets/locales/es.json
@@ -54,7 +54,6 @@
     "NO_DATA_SHORT": "No data available"
   },
   "HELP": {
-    "VERSION": "Albion Killbot v{{ version }}",
     "HELP": "Mostrar Lista de Comandos.",
     "CHANNEL": "Establecer Canal para enviar notificaciones",
     "LANGUAGE": "Establecer idioma de bot.",
@@ -68,7 +67,12 @@
     "RANKING": "Display rankings.",
     "SUBSCRIPTION": "Check or activate your subscription.",
     "PREFIX": "Change bot prefix.",
-    "SETTINGS": "Change settings for your server."
+    "SETTINGS": "Change settings for your server.",
+    "VERSION": "Check bot version."
+  },
+  "VERSION": {
+    "PACKAGE_VERSION": "Albion Killbot v{{ version }}",
+    "VERSION_NOT_FOUND": "Unable to retrieve bot version."
   },
   "CHANNEL": {
     "NO_CHANNEL": "Ingrese un canal para las notificaciones",

--- a/server/src/assets/locales/fr.json
+++ b/server/src/assets/locales/fr.json
@@ -54,7 +54,6 @@
     "NO_DATA_SHORT": "Aucune donnée disponible"
   },
   "HELP": {
-    "VERSION": "Albion Killbot v{{ version }}",
     "HELP": "Afficher la liste des commandes du bot.",
     "CHANNEL": "Définir le channel pour envoyer les notifications.",
     "LANGUAGE": "Définir la langue du bot.",
@@ -68,7 +67,12 @@
     "RANKING": "Affiche les classements.",
     "SUBSCRIPTION": "Vérifie ou active votre Souscription.",
     "PREFIX": "Change le prefixe du bot.",
-    "SETTINGS": "Change settings for your server."
+    "SETTINGS": "Change settings for your server.",
+    "VERSION": "Check bot version."
+  },
+  "VERSION": {
+    "PACKAGE_VERSION": "Albion Killbot v{{ version }}",
+    "VERSION_NOT_FOUND": "Unable to retrieve bot version."
   },
   "CHANNEL": {
     "NO_CHANNEL": "Veuillez sélectionner un canal dans lequel les notifications seront envoyées.",

--- a/server/src/assets/locales/pt.json
+++ b/server/src/assets/locales/pt.json
@@ -54,7 +54,6 @@
     "NO_DATA_SHORT": "Sem dados"
   },
   "HELP": {
-    "VERSION": "Albion Killbot v{{ version }}",
     "HELP": "Mostra a lista de comandos do bot.",
     "CHANNEL": "Define o canal para mostrar as notificações.",
     "LANGUAGE": "Define o idioma do bot.",
@@ -68,7 +67,12 @@
     "RANKING": "Mostra os rankings.",
     "SUBSCRIPTION": "Verifica ou ativa sua assinatura.",
     "PREFIX": "Muda o prefixo do bot.",
-    "SETTINGS": "Mudar as configurações do seu servidor."
+    "SETTINGS": "Mudar as configurações do seu servidor.",
+    "VERSION": "Verifica a versão do bot."
+  },
+  "VERSION": {
+    "PACKAGE_VERSION": "Albion Killbot v{{ version }}",
+    "VERSION_NOT_FOUND": "Não foi possível carregar a versão do bot."
   },
   "CHANNEL": {
     "NO_CHANNEL": "Por favor, insira o canal para receber as notificações.",

--- a/server/src/assets/locales/ru.json
+++ b/server/src/assets/locales/ru.json
@@ -54,7 +54,6 @@
     "NO_DATA_SHORT": "No data available"
   },
   "HELP": {
-    "VERSION": "Анонсер версии {{ version }}",
     "HELP": "Показать список команд бота.",
     "CHANNEL": "Задает канал для отправки уведомлений.",
     "LANGUAGE": "Установить язык бота.",
@@ -68,7 +67,12 @@
     "RANKING": "Display rankings.",
     "SUBSCRIPTION": "Check or activate your subscription.",
     "PREFIX": "Change bot prefix.",
-    "SETTINGS": "Change settings for your server."
+    "SETTINGS": "Change settings for your server.",
+    "VERSION": "Check bot version."
+  },
+  "VERSION": {
+    "PACKAGE_VERSION": "Albion Killbot v{{ version }}",
+    "VERSION_NOT_FOUND": "Unable to retrieve bot version."
   },
   "CHANNEL": {
     "NO_CHANNEL": "Пожалуйста, введите канал для уведомлений.",

--- a/server/src/helpers/discord.js
+++ b/server/src/helpers/discord.js
@@ -1,0 +1,42 @@
+const { Permissions } = require("discord.js");
+
+const isAdmin = (permissions) => {
+  const bitPermissions = new Permissions(permissions);
+  return bitPermissions.has(Permissions.FLAGS.ADMINISTRATOR);
+};
+
+const transformGuild = (guild) => {
+  const transformedGuild = {
+    id: guild.id,
+    name: guild.name,
+    icon: guild.icon,
+    owner: guild.owner,
+  };
+
+  if (guild.permissions) {
+    transformedGuild.admin = isAdmin(guild.permissions);
+  }
+
+  if (guild.roles) {
+    transformedGuild.roles = guild.roles.map((role) => ({
+      id: role.id,
+      name: role.name,
+      permission: role.permissions,
+    }));
+  }
+
+  return transformedGuild;
+};
+
+const transformChannel = (channel) => ({
+  id: channel.id,
+  name: channel.name,
+  type: channel.type,
+  parentId: channel.parent_id,
+});
+
+module.exports = {
+  isAdmin,
+  transformChannel,
+  transformGuild,
+};

--- a/server/src/helpers/discord.js
+++ b/server/src/helpers/discord.js
@@ -13,16 +13,12 @@ const transformGuild = (guild) => {
     owner: guild.owner,
   };
 
-  if (guild.permissions) {
-    transformedGuild.admin = isAdmin(guild.permissions);
+  if (guild.owner) {
+    transformGuild.owner = guild.owner;
   }
 
-  if (guild.roles) {
-    transformedGuild.roles = guild.roles.map((role) => ({
-      id: role.id,
-      name: role.name,
-      permission: role.permissions,
-    }));
+  if (guild.permissions) {
+    transformedGuild.admin = isAdmin(guild.permissions);
   }
 
   return transformedGuild;

--- a/server/src/interfaces/api/controllers/servers.js
+++ b/server/src/interfaces/api/controllers/servers.js
@@ -1,38 +1,48 @@
+const logger = require("../../../helpers/logger");
 const serversService = require("../../../services/servers");
 const settingsService = require("../../../services/settings");
 const subscriptionService = require("../../../services/subscriptions");
 const trackService = require("../../../services/track");
-const usersService = require("../../../services/users");
 
 async function getServers(req, res) {
   try {
     const { accessToken } = req.session.discord;
+    if (!accessToken) return res.sendStatus(403);
 
-    const userServers = await usersService.getCurrentUserServers(accessToken);
+    const userServers = await serversService.getServers(accessToken);
 
     return res.send(userServers);
   } catch (error) {
-    return res.sendStatus(403);
+    logger.error(`Unknown error:`, error);
+    return res.sendStatus(500);
   }
 }
 
 async function getServer(req, res) {
-  const { serverId } = req.params;
-  const server = await serversService.getServer(serverId);
+  try {
+    const { accessToken } = req.session.discord;
+    if (!accessToken) return res.sendStatus(403);
 
-  const settings = await settingsService.getSettings(serverId);
-  server.settings = settings;
+    const { serverId } = req.params;
+    const server = await serversService.getServer(serverId);
 
-  const subscription = await subscriptionService.getSubscriptionByServerId(serverId);
-  server.subscription = subscription;
+    const settings = await settingsService.getSettings(serverId);
+    server.settings = settings;
 
-  const limits = await trackService.getLimitsByServerId(serverId);
-  server.limits = limits;
+    const subscription = await subscriptionService.getSubscriptionByServerId(serverId);
+    server.subscription = subscription;
 
-  const track = await trackService.getTrack(serverId);
-  server.track = track;
+    const limits = await trackService.getLimitsByServerId(serverId);
+    server.limits = limits;
 
-  return res.send(server);
+    const track = await trackService.getTrack(serverId);
+    server.track = track;
+
+    return res.send(server);
+  } catch (error) {
+    logger.error(`Unknown error:`, error);
+    return res.sendStatus(500);
+  }
 }
 
 async function setServerSettings(req, res) {

--- a/server/src/interfaces/api/controllers/servers.js
+++ b/server/src/interfaces/api/controllers/servers.js
@@ -2,6 +2,19 @@ const serversService = require("../../../services/servers");
 const settingsService = require("../../../services/settings");
 const subscriptionService = require("../../../services/subscriptions");
 const trackService = require("../../../services/track");
+const usersService = require("../../../services/users");
+
+async function getServers(req, res) {
+  try {
+    const { accessToken } = req.session.discord;
+
+    const userServers = await usersService.getCurrentUserServers(accessToken);
+
+    return res.send(userServers);
+  } catch (error) {
+    return res.sendStatus(403);
+  }
+}
 
 async function getServer(req, res) {
   const { serverId } = req.params;
@@ -55,6 +68,7 @@ async function setServerTrack(req, res) {
 
 module.exports = {
   getServer,
+  getServers,
   setServerSettings,
   setServerTrack,
 };

--- a/server/src/interfaces/api/controllers/users.js
+++ b/server/src/interfaces/api/controllers/users.js
@@ -10,16 +10,6 @@ async function getUser(req, res) {
   }
 }
 
-async function getUserServers(req, res) {
-  try {
-    const { accessToken } = req.session.discord;
-    return res.send(await usersService.getCurrentUserServers(accessToken));
-  } catch (error) {
-    return res.sendStatus(403);
-  }
-}
-
 module.exports = {
   getUser,
-  getUserServers,
 };

--- a/server/src/interfaces/api/routes/servers.js
+++ b/server/src/interfaces/api/routes/servers.js
@@ -262,7 +262,7 @@ router.get(`/:serverId`, serversController.getServer);
  *             schema:
  *               $ref: '#/components/schemas/Settings'
  */
-router.put(`/:serverId/settings`, serversController.setServerSettings);
+router.put(`/:serverId/settings`, serversController.isServerAdmin, serversController.setServerSettings);
 
 /**
  * @openapi
@@ -290,7 +290,7 @@ router.put(`/:serverId/settings`, serversController.setServerSettings);
  *             schema:
  *               $ref: '#/components/schemas/Track'
  */
-router.put(`/:serverId/track`, serversController.setServerTrack);
+router.put(`/:serverId/track`, serversController.isServerAdmin, serversController.setServerTrack);
 
 module.exports = {
   path: "/servers",

--- a/server/src/interfaces/api/routes/servers.js
+++ b/server/src/interfaces/api/routes/servers.js
@@ -10,7 +10,7 @@ router.use(authenticated);
  * @openapi
  * components:
  *  schemas:
- *    Server:
+ *    ServerPartial:
  *      type: object
  *      properties:
  *        id:
@@ -28,27 +28,44 @@ router.use(authenticated);
  *          description: Discord server icon, to be used with the default icon url.
  *          readOnly: true
  *          example: "a_70cacbcd2ce03227ca160f18d250c868"
- *        channels:
- *          type: array
- *          items:
- *            $ref: '#/components/schemas/Channel'
- *        settings:
- *          $ref: '#/components/schemas/Settings'
- *        limits:
- *          type: object
- *          properties:
- *            players:
- *              type: number
- *              default: 10
- *            guilds:
- *              type: number
- *              default: 1
- *            alliances:
- *              type: number
- *              default: 1
- *        track:
+ *        owner:
+ *          type: boolean
+ *          description: If the current user is the server owner
  *          readOnly: true
- *          $ref: '#/components/schemas/Track'
+ *          example: true
+ *        admin:
+ *          type: boolean
+ *          description: If the current user is the server admin
+ *          readOnly: true
+ *          example: true
+ *        bot:
+ *          type: boolean
+ *          description: If the current bot is present on the server
+ *          readOnly: true
+ *          example: true
+ *
+ *    Server:
+ *      allOf:
+ *        - $ref: '#components/schemas/ServerPartial'
+ *        - type: object
+ *          properties:
+ *            settings:
+ *              $ref: '#/components/schemas/Settings'
+ *            limits:
+ *              type: object
+ *              properties:
+ *                players:
+ *                  type: number
+ *                  default: 10
+ *                guilds:
+ *                  type: number
+ *                  default: 1
+ *                alliances:
+ *                  type: number
+ *                  default: 1
+ *            track:
+ *              readOnly: true
+ *              $ref: '#/components/schemas/Track'
  *
  *    Channel:
  *      type: object
@@ -177,6 +194,27 @@ router.use(authenticated);
  *          description: Albion name
  *          example: "Gray Death"
  */
+
+/**
+ * @openapi
+ * /users/me/servers:
+ *   get:
+ *     tags: [Servers]
+ *     summary: Return list of servers for current user
+ *     operationId: getServers
+ *     responses:
+ *       200:
+ *         description: List of servers
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/ServerPartial'
+ *       403:
+ *         description: Unable to authenticate
+ */
+router.get(`/`, serversController.getServers);
 
 /**
  * @openapi

--- a/server/src/interfaces/api/routes/servers.js
+++ b/server/src/interfaces/api/routes/servers.js
@@ -10,7 +10,7 @@ router.use(authenticated);
  * @openapi
  * components:
  *  schemas:
- *    ServerPartial:
+ *    ServerBase:
  *      type: object
  *      properties:
  *        id:
@@ -28,29 +28,38 @@ router.use(authenticated);
  *          description: Discord server icon, to be used with the default icon url.
  *          readOnly: true
  *          example: "a_70cacbcd2ce03227ca160f18d250c868"
- *        owner:
- *          type: boolean
- *          description: If the current user is the server owner
- *          readOnly: true
- *          example: true
- *        admin:
- *          type: boolean
- *          description: If the current user is the server admin
- *          readOnly: true
- *          example: true
- *        bot:
- *          type: boolean
- *          description: If the current bot is present on the server
- *          readOnly: true
- *          example: true
+ *
+ *    ServerPartial:
+ *      allOf:
+ *        - $ref: '#components/schemas/ServerBase'
+ *        - type: object
+ *          properties:
+ *            owner:
+ *              type: boolean
+ *              description: If the current user is the server owner
+ *              readOnly: true
+ *              example: true
+ *            admin:
+ *              type: boolean
+ *              description: If the current user is the server admin
+ *              readOnly: true
+ *              example: true
+ *            bot:
+ *              type: boolean
+ *              description: If the current bot is present on the server
+ *              readOnly: true
+ *              example: true
  *
  *    Server:
  *      allOf:
- *        - $ref: '#components/schemas/ServerPartial'
+ *        - $ref: '#components/schemas/ServerBase'
  *        - type: object
  *          properties:
- *            settings:
- *              $ref: '#/components/schemas/Settings'
+ *            channels:
+ *              type: array
+ *              readOnly: true
+ *              items:
+ *                $ref: '#/components/schemas/Channel'
  *            limits:
  *              type: object
  *              properties:
@@ -63,9 +72,13 @@ router.use(authenticated);
  *                alliances:
  *                  type: number
  *                  default: 1
+ *            settings:
+ *              $ref: '#/components/schemas/Settings'
+ *            subscription:
+ *              $ref: '#/components/schemas/Subscription'
  *            track:
- *              readOnly: true
  *              $ref: '#/components/schemas/Track'
+ *
  *
  *    Channel:
  *      type: object
@@ -136,22 +149,6 @@ router.use(authenticated);
  *                type: string
  *                description: Setting for Guild Rankings
  *                default: "daily"
- *        subscription:
- *          type: object
- *          readOnly: true
- *          properties:
- *            expires:
- *              type: string
- *              format: date-time
- *              description: Subscription expiration date
- *            owner:
- *              type: string
- *              description: Discord user id of the subscription owner
- *              example: "796813403200028682"
- *            patreon:
- *              type: string
- *              description: Patreon user id of the subscription owner
- *              example: "17225165"
  *
  *    Category:
  *      type: object

--- a/server/src/interfaces/api/routes/users.js
+++ b/server/src/interfaces/api/routes/users.js
@@ -71,40 +71,6 @@ router.use(disableCache);
  *          description: User has multi-factor enabled
  *          readOnly: true
  *          example: false
- *
- *    ServerPartial:
- *      type: object
- *      properties:
- *        id:
- *          type: string
- *          description: Discord server id.
- *          readOnly: true
- *          example: "159962941502783488"
- *        name:
- *          type: string
- *          description: Server name.
- *          readOnly: true
- *          example: "Discord Server Name"
- *        icon:
- *          type: string
- *          description: Discord server icon, to be used with the default icon url.
- *          readOnly: true
- *          example: "a_70cacbcd2ce03227ca160f18d250c868"
- *        owner:
- *          type: boolean
- *          description: If the current user is the server owner
- *          readOnly: true
- *          example: true
- *        admin:
- *          type: boolean
- *          description: If the current user is the server admin
- *          readOnly: true
- *          example: true
- *        bot:
- *          type: boolean
- *          description: If the current bot is present on the server
- *          readOnly: true
- *          example: true
  */
 
 /**
@@ -125,27 +91,6 @@ router.use(disableCache);
  *         description: Unable to authenticate
  */
 router.get(`/me`, usersController.getUser);
-
-/**
- * @openapi
- * /users/me/servers:
- *   get:
- *     tags: [Users]
- *     summary: Return list of servers for current user
- *     operationId: getUserServers
- *     responses:
- *       200:
- *         description: List of user servers
- *         content:
- *           application/json:
- *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/ServerPartial'
- *       403:
- *         description: Unable to authenticate
- */
-router.get(`/me/servers`, usersController.getUserServers);
 
 module.exports = {
   path: "/users",

--- a/server/src/interfaces/bot/commands/help.js
+++ b/server/src/interfaces/bot/commands/help.js
@@ -8,16 +8,9 @@ const command = {
   name: "help",
   description: getLocale().t("HELP.HELP"),
   type: InteractionType.Ping,
-  default_permission: true,
+  default_member_permissions: "0",
   handle: async (interaction, { t }) => {
     let response = "```\n";
-    if (process.env.npm_package_version) {
-      response += t("HELP.VERSION", {
-        version: process.env.npm_package_version,
-      });
-      response += "\n\n";
-    }
-
     const commands = getCommands();
     for (const command of commands) {
       const commandKey = `/${command.name}`;

--- a/server/src/interfaces/bot/commands/ranking.js
+++ b/server/src/interfaces/bot/commands/ranking.js
@@ -30,7 +30,7 @@ const command = {
   name: "ranking",
   description: t("HELP.RANKING"),
   type: InteractionType.Ping,
-  default_permission: true,
+  default_member_permissions: "0",
   options,
   handle: async (interaction, { settings, track, t }) => {
     const rankingType = interaction.options.getString("ranking");

--- a/server/src/interfaces/bot/commands/version.js
+++ b/server/src/interfaces/bot/commands/version.js
@@ -1,0 +1,27 @@
+const { InteractionType } = require("discord-api-types/v10");
+const { getLocale } = require("../../../helpers/locale");
+
+const command = {
+  name: "version",
+  description: getLocale().t("HELP.VERSION"),
+  type: InteractionType.Ping,
+  default_permission: true,
+  handle: async (interaction, { t }) => {
+    let response = "```\n";
+    if (process.env.npm_package_version) {
+      response += t("VERSION.PACKAGE_VERSION", {
+        version: process.env.npm_package_version,
+      });
+    } else {
+      response += t("VERSION.NOT_FOUND");
+    }
+    response += "```";
+
+    return interaction.reply({
+      content: response,
+      ephemeral: true,
+    });
+  },
+};
+
+module.exports = command;

--- a/server/src/ports/discord.js
+++ b/server/src/ports/discord.js
@@ -1,4 +1,5 @@
 const discordApiClient = require("../adapters/discordApiClient");
+const discordHelper = require("../helpers/discord");
 
 const { DISCORD_TOKEN } = process.env;
 
@@ -16,12 +17,7 @@ async function getMe(accessToken) {
 
 async function getMeGuilds(accessToken) {
   const guilds = await discordApiClient.getMeGuilds(`Bearer ${accessToken}`);
-  return guilds.map((guild) => ({
-    id: guild.id,
-    name: guild.name,
-    icon: guild.icon,
-    owner: guild.owner,
-  }));
+  return guilds.map(discordHelper.transformGuild);
 }
 
 async function getBotGuilds() {
@@ -30,27 +26,12 @@ async function getBotGuilds() {
 
 async function getGuild(guildId) {
   const guild = await discordApiClient.getGuild(`Bot ${DISCORD_TOKEN}`, guildId);
-  return {
-    id: guild.id,
-    name: guild.name,
-    icon: guild.icon,
-    owner: guild.owner_id,
-    roles: guild.roles.map((role) => ({
-      id: role.id,
-      name: role.name,
-      permission: role.permissions,
-    })),
-  };
+  return discordHelper.transformGuild(guild);
 }
 
 async function getGuildChannels(guildId) {
   const channels = await discordApiClient.getGuildChannels(`Bot ${DISCORD_TOKEN}`, guildId);
-  return channels.map((channel) => ({
-    id: channel.id,
-    name: channel.name,
-    type: channel.type,
-    parentId: channel.parent_id,
-  }));
+  return channels.map(discordHelper.transformChannel);
 }
 
 module.exports = {

--- a/server/src/services/servers.js
+++ b/server/src/services/servers.js
@@ -1,6 +1,23 @@
 const discord = require("../ports/discord");
 const logger = require("../helpers/logger");
 
+async function getServers(accessToken) {
+  try {
+    const botServerIds = (await discord.getBotGuilds()).map((s) => s.id);
+    const servers = await discord.getMeGuilds(accessToken);
+
+    return servers
+      .filter((server) => server.owner || server.admin)
+      .map((server) => {
+        server.bot = botServerIds.indexOf(server.id) >= 0;
+        return server;
+      });
+  } catch (e) {
+    logger.error(`Error while retrieving user guilds:`, e);
+    throw e;
+  }
+}
+
 async function getServer(serverId) {
   try {
     const guild = await discord.getGuild(serverId);
@@ -18,4 +35,5 @@ async function getServer(serverId) {
 
 module.exports = {
   getServer,
+  getServers,
 };

--- a/server/src/services/servers.js
+++ b/server/src/services/servers.js
@@ -23,7 +23,6 @@ async function getServer(serverId) {
     const guild = await discord.getGuild(serverId);
     const channels = await discord.getGuildChannels(serverId);
 
-    guild.bot = true;
     guild.channels = channels;
 
     return guild;

--- a/server/src/services/users.js
+++ b/server/src/services/users.js
@@ -10,24 +10,6 @@ async function getCurrentUser(accessToken) {
   }
 }
 
-async function getCurrentUserServers(accessToken) {
-  try {
-    const botServerIds = (await discord.getBotGuilds()).map((s) => s.id);
-    const servers = await discord.getMeGuilds(accessToken);
-
-    return servers
-      .filter((server) => server.owner || server.admin)
-      .map((server) => {
-        server.bot = botServerIds.indexOf(server.id) >= 0;
-        return server;
-      });
-  } catch (e) {
-    logger.error(`Error while retrieving user guilds:`, e);
-    throw e;
-  }
-}
-
 module.exports = {
   getCurrentUser,
-  getCurrentUserServers,
 };

--- a/server/src/services/users.js
+++ b/server/src/services/users.js
@@ -13,17 +13,14 @@ async function getCurrentUser(accessToken) {
 async function getCurrentUserServers(accessToken) {
   try {
     const botServerIds = (await discord.getBotGuilds()).map((s) => s.id);
-    const servers = (await discord.getMeGuilds(accessToken))
-      // TODO: Show servers where the user has Administrator permission
-      .filter((server) => server.owner)
+    const servers = await discord.getMeGuilds(accessToken);
+
+    return servers
+      .filter((server) => server.owner || server.admin)
       .map((server) => {
-        return {
-          ...server,
-          admin: true,
-          bot: botServerIds.indexOf(server.id) >= 0,
-        };
+        server.bot = botServerIds.indexOf(server.id) >= 0;
+        return server;
       });
-    return servers;
   } catch (e) {
     logger.error(`Error while retrieving user guilds:`, e);
     throw e;


### PR DESCRIPTION
# Description
- Fix permissions for rankings command
- Move version to its own command
- Move servers endpoint out of users controller
- Move servers endpoint: dashboard followup
- Add helper method to verify Admin permissions
- Move getServer to servers services
- Update controller to service changes
- Update swagger docs and remove unused fields
- Add middleware to validate server admin
- Adjust Premium page to improve subscription assignment

Fixes #132

# PR Checklist

- [x] I tested my changes locally
- [ ] I added new tests (if applicabble)
- [ ] I guaranteed that the coverage will not to red threshold
- [x] I updated the Documentation accordingly
