### PR TITLE
Add independent death settings

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -20,9 +20,8 @@
         "@types/node": "^17.0.34",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.4",
-        "bootstrap": "^5.1.3",
         "react": "^18.1.0",
-        "react-bootstrap": "^2.4.0",
+        "react-bootstrap": "^2.5.0",
         "react-content-loader": "^6.2.0",
         "react-cookienotice": "^5.3.1",
         "react-dom": "^18.1.0",
@@ -33,7 +32,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "@types/bootstrap": "^5.1.12",
+        "@types/bootstrap": "^5.2.5",
         "@types/styled-components": "^5.1.25",
         "prettier": "^2.6.2",
         "react-test-renderer": "^18.1.0",
@@ -2803,6 +2802,17 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.3.0.tgz",
+      "integrity": "sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.2.tgz",
@@ -2838,14 +2848,14 @@
       }
     },
     "node_modules/@restart/ui": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.2.0.tgz",
-      "integrity": "sha512-oIh2t3tG8drZtZ9SlaV5CY6wGsUViHk8ZajjhcI+74IQHyWy+AnxDv8rJR5wVgsgcgrPBUvGNkC1AEdcGNPaLQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.4.0.tgz",
+      "integrity": "sha512-5dDj5uDzUgK1iijWPRg6AnxjkHM04XhTQDJirM1h/8tIc7KyLtF9YyjcCpNEn259hPMXswpkfXKNgiag0skPFg==",
       "dependencies": {
-        "@babel/runtime": "^7.13.16",
-        "@popperjs/core": "^2.10.1",
-        "@react-aria/ssr": "^3.0.1",
-        "@restart/hooks": "^0.4.0",
+        "@babel/runtime": "^7.18.3",
+        "@popperjs/core": "^2.11.5",
+        "@react-aria/ssr": "^3.2.0",
+        "@restart/hooks": "^0.4.7",
         "@types/warning": "^3.0.0",
         "dequal": "^2.0.2",
         "dom-helpers": "^5.2.0",
@@ -2855,17 +2865,6 @@
       "peerDependencies": {
         "react": ">=16.14.0",
         "react-dom": ">=16.14.0"
-      }
-    },
-    "node_modules/@restart/ui/node_modules/@react-aria/ssr": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.1.2.tgz",
-      "integrity": "sha512-amXY11ImpokvkTMeKRHjsSsG7v1yzzs6yeqArCyBIk60J3Yhgxwx9Cah+Uu/804ATFwqzN22AXIo7SdtIaMP+g==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3345,9 +3344,9 @@
       }
     },
     "node_modules/@types/bootstrap": {
-      "version": "5.1.12",
-      "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.1.12.tgz",
-      "integrity": "sha512-pSS5BGEgepwzdbsBGswBWFmgrnYpp7c4UfuYe1FJWwkrcjm/JVwfG4gBkOYtd92Otd3RdJK0ByBWMkBROfLEPw==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.2.5.tgz",
+      "integrity": "sha512-VnalUJ3E/oaV3DYrauEc/sSPpaEPxTV09twSEzY4KFRvyuGlrZUSqG95XZ6ReAi0YMZIs7rXxdngDK2X1YONQA==",
       "dev": true,
       "dependencies": {
         "@popperjs/core": "^2.9.2"
@@ -4798,18 +4797,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
-    "node_modules/bootstrap": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.10.2"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5967,9 +5954,9 @@
       }
     },
     "node_modules/dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "engines": {
         "node": ">=6"
       }
@@ -12079,13 +12066,13 @@
       }
     },
     "node_modules/react-bootstrap": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.4.0.tgz",
-      "integrity": "sha512-dn599jNK1Fg5GGjJH+lQQDwELVzigh/MdusKpB/0el+sCjsO5MZDH5gRMmBjRhC+vb7VlCDr6OXffPIDSkNMLw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.5.0.tgz",
+      "integrity": "sha512-j/aLR+okzbYk61TM3eDOU1NqOqnUdwyVrF+ojoCRUxPdzc2R0xXvqyRsjSoyRoCo7n82Fs/LWjPCin/QJNdwvA==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "@restart/hooks": "^0.4.6",
-        "@restart/ui": "^1.2.0",
+        "@restart/ui": "^1.3.1",
         "@types/react-transition-group": "^4.4.4",
         "classnames": "^2.3.1",
         "dom-helpers": "^5.2.1",
@@ -17013,6 +17000,14 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
       "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
+    "@react-aria/ssr": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.3.0.tgz",
+      "integrity": "sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==",
+      "requires": {
+        "@babel/runtime": "^7.6.2"
+      }
+    },
     "@reduxjs/toolkit": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.2.tgz",
@@ -17033,29 +17028,19 @@
       }
     },
     "@restart/ui": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.2.0.tgz",
-      "integrity": "sha512-oIh2t3tG8drZtZ9SlaV5CY6wGsUViHk8ZajjhcI+74IQHyWy+AnxDv8rJR5wVgsgcgrPBUvGNkC1AEdcGNPaLQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.4.0.tgz",
+      "integrity": "sha512-5dDj5uDzUgK1iijWPRg6AnxjkHM04XhTQDJirM1h/8tIc7KyLtF9YyjcCpNEn259hPMXswpkfXKNgiag0skPFg==",
       "requires": {
-        "@babel/runtime": "^7.13.16",
-        "@popperjs/core": "^2.10.1",
-        "@react-aria/ssr": "^3.0.1",
-        "@restart/hooks": "^0.4.0",
+        "@babel/runtime": "^7.18.3",
+        "@popperjs/core": "^2.11.5",
+        "@react-aria/ssr": "^3.2.0",
+        "@restart/hooks": "^0.4.7",
         "@types/warning": "^3.0.0",
         "dequal": "^2.0.2",
         "dom-helpers": "^5.2.0",
         "uncontrollable": "^7.2.1",
         "warning": "^4.0.3"
-      },
-      "dependencies": {
-        "@react-aria/ssr": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.1.2.tgz",
-          "integrity": "sha512-amXY11ImpokvkTMeKRHjsSsG7v1yzzs6yeqArCyBIk60J3Yhgxwx9Cah+Uu/804ATFwqzN22AXIo7SdtIaMP+g==",
-          "requires": {
-            "@babel/runtime": "^7.6.2"
-          }
-        }
       }
     },
     "@rollup/plugin-babel": {
@@ -17382,9 +17367,9 @@
       }
     },
     "@types/bootstrap": {
-      "version": "5.1.12",
-      "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.1.12.tgz",
-      "integrity": "sha512-pSS5BGEgepwzdbsBGswBWFmgrnYpp7c4UfuYe1FJWwkrcjm/JVwfG4gBkOYtd92Otd3RdJK0ByBWMkBROfLEPw==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.2.5.tgz",
+      "integrity": "sha512-VnalUJ3E/oaV3DYrauEc/sSPpaEPxTV09twSEzY4KFRvyuGlrZUSqG95XZ6ReAi0YMZIs7rXxdngDK2X1YONQA==",
       "dev": true,
       "requires": {
         "@popperjs/core": "^2.9.2"
@@ -18529,12 +18514,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
-    "bootstrap": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
-      "requires": {}
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -19359,9 +19338,9 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "destroy": {
       "version": "1.2.0",
@@ -23676,13 +23655,13 @@
       }
     },
     "react-bootstrap": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.4.0.tgz",
-      "integrity": "sha512-dn599jNK1Fg5GGjJH+lQQDwELVzigh/MdusKpB/0el+sCjsO5MZDH5gRMmBjRhC+vb7VlCDr6OXffPIDSkNMLw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.5.0.tgz",
+      "integrity": "sha512-j/aLR+okzbYk61TM3eDOU1NqOqnUdwyVrF+ojoCRUxPdzc2R0xXvqyRsjSoyRoCo7n82Fs/LWjPCin/QJNdwvA==",
       "requires": {
         "@babel/runtime": "^7.17.2",
         "@restart/hooks": "^0.4.6",
-        "@restart/ui": "^1.2.0",
+        "@restart/ui": "^1.3.1",
         "@types/react-transition-group": "^4.4.4",
         "classnames": "^2.3.1",
         "dom-helpers": "^5.2.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -26,9 +26,8 @@
     "@types/node": "^17.0.34",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
-    "bootstrap": "^5.1.3",
     "react": "^18.1.0",
-    "react-bootstrap": "^2.4.0",
+    "react-bootstrap": "^2.5.0",
     "react-content-loader": "^6.2.0",
     "react-cookienotice": "^5.3.1",
     "react-dom": "^18.1.0",
@@ -39,7 +38,7 @@
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {
-    "@types/bootstrap": "^5.1.12",
+    "@types/bootstrap": "^5.2.5",
     "@types/styled-components": "^5.1.25",
     "prettier": "^2.6.2",
     "react-test-renderer": "^18.1.0",

--- a/dashboard/src/pages/Settings/index.tsx
+++ b/dashboard/src/pages/Settings/index.tsx
@@ -4,13 +4,16 @@ import Toast from "components/Toast";
 import { useAppDispatch, useAppSelector } from "helpers/hooks";
 import { capitalize, getLocaleName } from "helpers/utils";
 import { useEffect } from "react";
-import { Accordion, Button, Card, Col, Form, Row } from "react-bootstrap";
+import { Button, Card, Col, Form, Row, Tab, Tabs } from "react-bootstrap";
 import { useParams } from "react-router-dom";
 import { useFetchServerQuery, useUpdateSettingsMutation } from "store/api";
 import {
   loadSettings,
   setBattlesChannel,
   setBattlesEnabled,
+  setDeathsChannel,
+  setDeathsEnabled,
+  setDeathsMode,
   setKillsChannel,
   setKillsEnabled,
   setKillsMode,
@@ -22,7 +25,7 @@ import {
 } from "store/settings";
 
 const languages = ["en", "pt", "es", "fr", "ru"];
-const killModes = ["image", "text"];
+const notificationModes = ["image", "text"];
 const rankingModes = ["off", "hourly", "daily"];
 
 const Settings = () => {
@@ -56,7 +59,7 @@ const Settings = () => {
     );
   };
 
-  const renderKillModeOptions = (killMode: string) => {
+  const renderNotificationModeOptions = (killMode: string) => {
     return (
       <option key={killMode} value={killMode}>
         {capitalize(killMode)}
@@ -73,148 +76,177 @@ const Settings = () => {
   };
 
   const { channels } = server.data;
-  const { lang, kills, battles, rankings } = settings;
+  const { lang, kills, deaths, battles, rankings } = settings;
 
   return (
     <Card>
       <Form
-        className="p-2"
         onSubmit={async () => {
           await dispatchUpdateSettings({ serverId, settings });
         }}
       >
         <h4 className="d-flex justify-content-center py-2">Settings</h4>
-        <Form.Group controlId="language" className="p-2">
-          <Form.Label>Language</Form.Label>
-          <Form.Select
-            aria-label="Language select"
-            value={lang}
-            onChange={(e) => dispatch(setLang(e.target.value))}
-          >
-            {languages.map(renderLanguageOptions)}
-          </Form.Select>
-        </Form.Group>
-        <Accordion
-          alwaysOpen
-          defaultActiveKey={["kills", "battles", "rankings"]}
-          flush
-        >
-          <Accordion.Item eventKey="kills">
-            <Accordion.Header>Kills</Accordion.Header>
-            <Accordion.Body>
+        <Tabs>
+          <Tab eventKey="general" title="General" className="px-3">
+            <Form.Group controlId="language" className="mt-3">
+              <Form.Label>Language</Form.Label>
+              <Form.Select
+                aria-label="Language select"
+                value={lang}
+                onChange={(e) => dispatch(setLang(e.target.value))}
+              >
+                {languages.map(renderLanguageOptions)}
+              </Form.Select>
+            </Form.Group>
+          </Tab>
+
+          <Tab eventKey="kills" title="Kills" className="px-3">
+            <Form.Group controlId="kills-enabled" className="mt-3">
               <Form.Check
-                type="checkbox"
+                type="switch"
                 label="Enabled"
-                className="py-2"
                 checked={kills.enabled}
                 onChange={(e) => dispatch(setKillsEnabled(e.target.checked))}
               />
-              <Form.Group controlId="kills-channel" className="py-2">
-                <Form.Label>Notification Channel</Form.Label>
-                <ChannelInput
-                  aria-label="Kills channel"
-                  disabled={!kills.enabled}
-                  availableChannels={channels}
-                  value={kills.channel}
-                  onChannelChange={(channelId) =>
-                    dispatch(setKillsChannel(channelId))
-                  }
-                />
-              </Form.Group>
-              <Form.Group controlId="kills-mode" className="py-2">
-                <Form.Label>Mode</Form.Label>
-                <Form.Select
-                  aria-label="Language select"
-                  disabled={!kills.enabled}
-                  value={kills.mode}
-                  onChange={(e) => dispatch(setKillsMode(e.target.value))}
-                >
-                  {killModes.map(renderKillModeOptions)}
-                </Form.Select>
-              </Form.Group>
-            </Accordion.Body>
-          </Accordion.Item>
-          <Accordion.Item eventKey="battles">
-            <Accordion.Header>Battles</Accordion.Header>
-            <Accordion.Body>
+            </Form.Group>
+            <Form.Group controlId="kills-channel" className="py-2">
+              <Form.Label>Notification Channel</Form.Label>
+              <ChannelInput
+                aria-label="Kills channel"
+                disabled={!kills.enabled}
+                availableChannels={channels}
+                value={kills.channel}
+                onChannelChange={(channelId) =>
+                  dispatch(setKillsChannel(channelId))
+                }
+              />
+            </Form.Group>
+            <Form.Group controlId="kills-mode" className="py-2">
+              <Form.Label>Mode</Form.Label>
+              <Form.Select
+                aria-label="Notification mode"
+                disabled={!kills.enabled}
+                value={kills.mode}
+                onChange={(e) => dispatch(setKillsMode(e.target.value))}
+              >
+                {notificationModes.map(renderNotificationModeOptions)}
+              </Form.Select>
+            </Form.Group>
+          </Tab>
+
+          <Tab eventKey="deaths" title="Deaths" className="px-3">
+            <Form.Group controlId="kills-enabled" className="mt-3">
               <Form.Check
-                type="checkbox"
+                type="switch"
                 label="Enabled"
-                className="py-2"
+                checked={deaths.enabled}
+                onChange={(e) => dispatch(setDeathsEnabled(e.target.checked))}
+              />
+            </Form.Group>
+            <Form.Group controlId="kills-channel" className="py-2">
+              <Form.Label>Notification Channel</Form.Label>
+              <ChannelInput
+                aria-label="Deaths channel"
+                disabled={!deaths.enabled}
+                availableChannels={channels}
+                value={deaths.channel}
+                onChannelChange={(channelId) =>
+                  dispatch(setDeathsChannel(channelId))
+                }
+              />
+            </Form.Group>
+            <Form.Group controlId="deaths-mode" className="py-2">
+              <Form.Label>Mode</Form.Label>
+              <Form.Select
+                aria-label="Notification mode"
+                disabled={!deaths.enabled}
+                value={deaths.mode}
+                onChange={(e) => dispatch(setDeathsMode(e.target.value))}
+              >
+                {notificationModes.map(renderNotificationModeOptions)}
+              </Form.Select>
+            </Form.Group>
+          </Tab>
+
+          <Tab eventKey="battles" title="Battles" className="px-3">
+            <Form.Group controlId="kills-enabled" className="mt-3">
+              <Form.Check
+                type="switch"
+                label="Enabled"
                 checked={battles.enabled}
                 onChange={(e) => dispatch(setBattlesEnabled(e.target.checked))}
               />
-              <Form.Group controlId="battles-channel" className="py-2">
-                <Form.Label>Notification Channel</Form.Label>
-                <ChannelInput
-                  aria-label="Battles channel"
-                  disabled={!battles.enabled}
-                  availableChannels={channels}
-                  value={battles.channel}
-                  onChannelChange={(channelId) =>
-                    dispatch(setBattlesChannel(channelId))
-                  }
-                />
-              </Form.Group>
-            </Accordion.Body>
-          </Accordion.Item>
-          <Accordion.Item eventKey="rankings">
-            <Accordion.Header>Rankings</Accordion.Header>
-            <Accordion.Body>
+            </Form.Group>
+            <Form.Group controlId="battles-channel" className="py-2">
+              <Form.Label>Notification Channel</Form.Label>
+              <ChannelInput
+                aria-label="Battles channel"
+                disabled={!battles.enabled}
+                availableChannels={channels}
+                value={battles.channel}
+                onChannelChange={(channelId) =>
+                  dispatch(setBattlesChannel(channelId))
+                }
+              />
+            </Form.Group>
+          </Tab>
+
+          <Tab eventKey="rankings" title="Rankings" className="px-3">
+            <Form.Group controlId="kills-enabled" className="mt-3">
               <Form.Check
-                type="checkbox"
+                type="switch"
                 label="Enabled"
-                className="py-2"
                 checked={rankings.enabled}
                 onChange={(e) => dispatch(setRankingsEnabled(e.target.checked))}
               />
-              <Form.Group controlId="rankings-channel" className="py-2">
-                <Form.Label>Notification Channel</Form.Label>
-                <ChannelInput
-                  aria-label="Rankings channel"
-                  disabled={!rankings.enabled}
-                  availableChannels={channels}
-                  value={rankings.channel}
-                  onChannelChange={(channelId) =>
-                    dispatch(setRankingsChannel(channelId))
-                  }
-                />
-              </Form.Group>
-              <Row>
-                <Col sm={6}>
-                  <Form.Group controlId="rankings-pvp-mode" className="py-2">
-                    <Form.Label>PvP Ranking Mode</Form.Label>
-                    <Form.Select
-                      aria-label="PvP ranking mode select"
-                      disabled={!rankings.enabled}
-                      value={rankings.pvpRanking}
-                      onChange={(e) =>
-                        dispatch(setRankingsPvpRanking(e.target.value))
-                      }
-                    >
-                      {rankingModes.map(renderRankingModeOptions)}
-                    </Form.Select>
-                  </Form.Group>
-                </Col>
-                <Col sm={6}>
-                  <Form.Group controlId="rankings-guild-mode" className="py-2">
-                    <Form.Label>Guild Ranking Mode</Form.Label>
-                    <Form.Select
-                      aria-label="Guild ranking mode select"
-                      disabled={!rankings.enabled}
-                      value={rankings.guildRanking}
-                      onChange={(e) =>
-                        dispatch(setRankingsGuildRanking(e.target.value))
-                      }
-                    >
-                      {rankingModes.map(renderRankingModeOptions)}
-                    </Form.Select>
-                  </Form.Group>
-                </Col>
-              </Row>
-            </Accordion.Body>
-          </Accordion.Item>
-        </Accordion>
+            </Form.Group>
+            <Form.Group controlId="rankings-channel" className="py-2">
+              <Form.Label>Notification Channel</Form.Label>
+              <ChannelInput
+                aria-label="Rankings channel"
+                disabled={!rankings.enabled}
+                availableChannels={channels}
+                value={rankings.channel}
+                onChannelChange={(channelId) =>
+                  dispatch(setRankingsChannel(channelId))
+                }
+              />
+            </Form.Group>
+            <Row>
+              <Col sm={6}>
+                <Form.Group controlId="rankings-pvp-mode" className="py-2">
+                  <Form.Label>PvP Ranking Mode</Form.Label>
+                  <Form.Select
+                    aria-label="PvP ranking mode select"
+                    disabled={!rankings.enabled}
+                    value={rankings.pvpRanking}
+                    onChange={(e) =>
+                      dispatch(setRankingsPvpRanking(e.target.value))
+                    }
+                  >
+                    {rankingModes.map(renderRankingModeOptions)}
+                  </Form.Select>
+                </Form.Group>
+              </Col>
+              <Col sm={6}>
+                <Form.Group controlId="rankings-guild-mode" className="py-2">
+                  <Form.Label>Guild Ranking Mode</Form.Label>
+                  <Form.Select
+                    aria-label="Guild ranking mode select"
+                    disabled={!rankings.enabled}
+                    value={rankings.guildRanking}
+                    onChange={(e) =>
+                      dispatch(setRankingsGuildRanking(e.target.value))
+                    }
+                  >
+                    {rankingModes.map(renderRankingModeOptions)}
+                  </Form.Select>
+                </Form.Group>
+              </Col>
+            </Row>
+          </Tab>
+        </Tabs>
+
         <div className="p-3">
           <div className="d-flex justify-content-end">
             <Button

--- a/dashboard/src/pages/Settings/index.tsx
+++ b/dashboard/src/pages/Settings/index.tsx
@@ -85,8 +85,7 @@ const Settings = () => {
           await dispatchUpdateSettings({ serverId, settings });
         }}
       >
-        <h4 className="d-flex justify-content-center py-2">Settings</h4>
-        <Tabs>
+        <Tabs fill={true}>
           <Tab eventKey="general" title="General" className="px-3">
             <Form.Group controlId="language" className="mt-3">
               <Form.Label>Language</Form.Label>

--- a/dashboard/src/pages/Subscription/index.tsx
+++ b/dashboard/src/pages/Subscription/index.tsx
@@ -59,7 +59,6 @@ const SubscriptionPage = () => {
 
   return (
     <>
-      <h4 className="d-flex justify-content-center p-2">Subscription</h4>
       {subscriptions.isFetching && <Loader />}
       {subscriptions.isSuccess && renderServerSubscription()}
       {subscriptionAssignId && (

--- a/dashboard/src/pages/Track/index.tsx
+++ b/dashboard/src/pages/Track/index.tsx
@@ -218,7 +218,6 @@ const Track = () => {
       <Row className="g-3">
         <Col sm={12}>
           <Card>
-            <h4 className="d-flex justify-content-center p-2">Tracking List</h4>
             {renderTracking()}
             <div className="d-flex justify-content-end align-items-center p-3">
               <Button

--- a/dashboard/src/store/api.ts
+++ b/dashboard/src/store/api.ts
@@ -44,6 +44,11 @@ export interface Settings {
     channel: string;
     mode: string;
   };
+  deaths: {
+    enabled: boolean;
+    channel: string;
+    mode: string;
+  };
   battles: {
     enabled: boolean;
     channel: string;

--- a/dashboard/src/store/settings.ts
+++ b/dashboard/src/store/settings.ts
@@ -8,6 +8,11 @@ const initialState = {
     channel: "",
     mode: "image",
   },
+  deaths: {
+    enabled: true,
+    channel: "",
+    mode: "image",
+  },
   battles: {
     enabled: true,
     channel: "",
@@ -27,6 +32,7 @@ export const settingsSlice = createSlice({
     loadSettings: (state, { payload }: PayloadAction<Settings>) => {
       state.lang = payload.lang;
       state.kills = payload.kills;
+      state.deaths = payload.deaths;
       state.battles = payload.battles;
       state.rankings = payload.rankings;
     },
@@ -41,6 +47,15 @@ export const settingsSlice = createSlice({
     },
     setKillsMode: (state, action: PayloadAction<string>) => {
       state.kills.mode = action.payload;
+    },
+    setDeathsEnabled: (state, action: PayloadAction<boolean>) => {
+      state.deaths.enabled = action.payload;
+    },
+    setDeathsChannel: (state, action: PayloadAction<string>) => {
+      state.deaths.channel = action.payload;
+    },
+    setDeathsMode: (state, action: PayloadAction<string>) => {
+      state.deaths.mode = action.payload;
     },
     setBattlesEnabled: (state, action: PayloadAction<boolean>) => {
       state.battles.enabled = action.payload;
@@ -69,6 +84,9 @@ export const {
   setKillsEnabled,
   setKillsChannel,
   setKillsMode,
+  setDeathsEnabled,
+  setDeathsChannel,
+  setDeathsMode,
   setBattlesEnabled,
   setBattlesChannel,
   setRankingsEnabled,

--- a/dashboard/src/styles/global-styles.tsx
+++ b/dashboard/src/styles/global-styles.tsx
@@ -360,6 +360,32 @@ const globalStyle = createGlobalStyle<{ theme: ThemeProps }>`
       }
     }
   }
+
+  /* Bootstrap Tabs overrides */
+  .nav-tabs {
+    border-bottom: 1px solid;
+    border-color: ${({ theme }) => theme.background}77;
+
+    .nav-item {
+      .nav-link {
+          border: none;
+          color:  ${({ theme }) => theme.text};
+
+        &.active {
+          background: none;
+          background-image: linear-gradient(
+            rgba(255, 255, 255, 0.05),
+            rgba(255, 255, 255, 0.05)
+          );
+        }
+
+        &:hover {
+          border: none;
+          color: ${({ theme }) => theme.primary};
+        }
+      }
+    }
+  }
 `;
 
 export default globalStyle;

--- a/dashboard/src/styles/global-styles.tsx
+++ b/dashboard/src/styles/global-styles.tsx
@@ -136,7 +136,7 @@ const globalStyle = createGlobalStyle<{ theme: ThemeProps }>`
 
   /* Bootstrap Alert overrides */
   .alert {
-    border-radius: 0.75rem;
+    border-radius: 0.5rem;
 
       a {
         color: ${({ theme }) => theme.contrastText};
@@ -221,7 +221,7 @@ const globalStyle = createGlobalStyle<{ theme: ThemeProps }>`
     );
     box-shadow: 0px 2px 4px -1px rgb(0 0 0 / 20%),
       0px 4px 5px 0px rgb(0 0 0 / 14%), 0px 1px 10px 0px rgb(0 0 0 / 12%);
-    border-radius: 0.6rem;
+    border-radius: 0.5rem;
     color: ${({ theme }) => theme.text};
 
     .list-group {
@@ -298,7 +298,6 @@ const globalStyle = createGlobalStyle<{ theme: ThemeProps }>`
     );
     box-shadow: 0px 2px 4px -1px rgb(0 0 0 / 20%),
       0px 4px 5px 0px rgb(0 0 0 / 14%), 0px 1px 10px 0px rgb(0 0 0 / 12%);
-    border-radius: 0.75rem;
     color: ${({ theme }) => theme.text};
 
     .list-group-item {
@@ -310,6 +309,16 @@ const globalStyle = createGlobalStyle<{ theme: ThemeProps }>`
       a {
         background-color: inherit;
         color: inherit;
+      }
+
+      &:first-child {
+        border-top-left-radius: 0.5rem;
+        border-top-right-radius: 0.5rem;
+      }
+
+      &:last-child {
+        border-bottom-left-radius: 0.5rem;
+        border-bottom-right-radius: 0.5rem;
       }
 
       &:not(:last-child) {
@@ -368,8 +377,11 @@ const globalStyle = createGlobalStyle<{ theme: ThemeProps }>`
 
     .nav-item {
       .nav-link {
-          border: none;
-          color:  ${({ theme }) => theme.text};
+        border: none;
+        border-top-left-radius: 0.5rem;
+        border-top-right-radius: 0.5rem;
+        color:  ${({ theme }) => theme.text};
+        margin-bottom: 0;
 
         &.active {
           background: none;

--- a/server/migrations/1665060072790-split-kills-deaths.js
+++ b/server/migrations/1665060072790-split-kills-deaths.js
@@ -1,0 +1,33 @@
+const logger = require("../src/helpers/logger");
+const database = require("../src/ports/database");
+
+async function splitKillsDeathsSettings() {
+  const settingsCollection = database.getCollection("settings");
+
+  const settings = await settingsCollection.find({});
+  let setting = await settings.next();
+  while (setting) {
+    const { guild, kills, deaths } = setting;
+
+    if (kills && !deaths) {
+      logger.verbose(`Cloning server ${guild} kills settings as it does not contain death settings.`);
+
+      await settingsCollection.updateOne(
+        { _id: setting._id },
+        {
+          $set: { deaths: kills },
+        },
+      );
+    }
+
+    setting = await settings.next();
+  }
+}
+
+async function run() {
+  await splitKillsDeathsSettings();
+}
+
+module.exports = {
+  run,
+};

--- a/server/src/assets/locales/en.json
+++ b/server/src/assets/locales/en.json
@@ -147,6 +147,7 @@
   },
   "SETTINGS": {
     "KILLS": "Change settings for kill notifications.",
+    "DEATHS": "Change settings for death notifications.",
     "BATTLES": "Change settings for battle notifications.",
     "RANKINGS": "Change settings for ranking notifications.",
     "ENABLED": "Enable",

--- a/server/src/assets/locales/es.json
+++ b/server/src/assets/locales/es.json
@@ -147,6 +147,7 @@
   },
   "SETTINGS": {
     "KILLS": "Change settings for kill notifications.",
+    "DEATHS": "Change settings for death notifications.",
     "BATTLES": "Change settings for battle notifications.",
     "RANKINGS": "Change settings for ranking notifications.",
     "ENABLED": "Enable",

--- a/server/src/assets/locales/fr.json
+++ b/server/src/assets/locales/fr.json
@@ -147,6 +147,7 @@
   },
   "SETTINGS": {
     "KILLS": "Change settings for kill notifications.",
+    "DEATHS": "Change settings for death notifications.",
     "BATTLES": "Change settings for battle notifications.",
     "RANKINGS": "Change settings for ranking notifications.",
     "ENABLED": "Enable",

--- a/server/src/assets/locales/pt.json
+++ b/server/src/assets/locales/pt.json
@@ -146,21 +146,22 @@
     "SET_PREFIX": "O prefixo foi definido para '{{ prefix }}'. Seus comandos serão chamado usando {{prefix}}commando a partir de agora."
   },
   "SETTINGS": {
-    "KILLS": "Change settings for kill notifications.",
-    "BATTLES": "Change settings for battle notifications.",
-    "RANKINGS": "Change settings for ranking notifications.",
-    "ENABLED": "Enable",
-    "CHANNEL": "Channel",
+    "KILLS": "Mudar configurações de abates.",
+    "DEATHS": "Mudar configurações de mortes.",
+    "BATTLES": "Mudar configurações de batalhas.",
+    "RANKINGS": "Mudar configurações de rankings.",
+    "ENABLED": "Ativado",
+    "CHANNEL": "Canal",
     "MODE": {
-      "IMAGE": "Image",
-      "TEXT": "Text"
+      "IMAGE": "Imagem",
+      "TEXT": "Texto"
     },
-    "PVP_RANKING": "PvP Ranking",
-    "GUILD_RANKING": "Guild Ranking",
+    "PVP_RANKING": "Ranking PvP",
+    "GUILD_RANKING": "Ranking de Guilda",
     "FREQUENCIES": {
-      "OFF": "Off",
-      "HOURLY": "Every hour",
-      "DAILY": "Daily"
+      "OFF": "Desligado",
+      "HOURLY": "A cada hora",
+      "DAILY": "Diariamente"
     },
     "LANG": "Alterar idioma."
   }

--- a/server/src/assets/locales/ru.json
+++ b/server/src/assets/locales/ru.json
@@ -147,6 +147,7 @@
   },
   "SETTINGS": {
     "KILLS": "Change settings for kill notifications.",
+    "DEATHS": "Change settings for death notifications.",
     "BATTLES": "Change settings for battle notifications.",
     "RANKINGS": "Change settings for ranking notifications.",
     "ENABLED": "Enable",

--- a/server/src/interfaces/bot/commands/settings.js
+++ b/server/src/interfaces/bot/commands/settings.js
@@ -40,6 +40,39 @@ const kills = {
   ],
 };
 
+const deaths = {
+  name: "deaths",
+  description: t("SETTINGS.DEATHS"),
+  type: Subcommand,
+  options: [
+    {
+      name: "enabled",
+      description: t("SETTINGS.ENABLED"),
+      type: Boolean,
+    },
+    {
+      name: "channel",
+      description: t("SETTINGS.CHANNEL"),
+      type: Channel,
+    },
+    {
+      name: "mode",
+      description: t("SETTINGS.CHANNEL"),
+      type: String,
+      choices: [
+        {
+          name: t("SETTINGS.MODE.IMAGE"),
+          value: "image",
+        },
+        {
+          name: t("SETTINGS.MODE.TEXT"),
+          value: "text",
+        },
+      ],
+    },
+  ],
+};
+
 const battles = {
   name: "battles",
   description: t("SETTINGS.BATTLES"),
@@ -148,7 +181,7 @@ const command = {
   description: t("HELP.SETTINGS"),
   type: InteractionType.Ping,
   default_member_permissions: "0",
-  options: [kills, battles, rankings, lang],
+  options: [kills, deaths, battles, rankings, lang],
   handle: async (interaction, { settings, t }) => {
     const reply = async (content, ephemeral = true) => await interaction.reply({ content, ephemeral });
     const editReply = async (content, ephemeral = true) => await interaction.editReply({ content, ephemeral });
@@ -156,6 +189,20 @@ const command = {
     const subcommands = {
       kills: async () => {
         const category = "kills";
+        settings = getCommonOptions(settings, category, interaction);
+
+        const mode = interaction.options.getString("mode");
+        if (mode != null) settings[category].mode = mode;
+
+        await interaction.deferReply({ ephemeral: true });
+        await setSettings(interaction.guild.id, settings);
+
+        let reply = printCommonOptions(settings, category, interaction, t);
+        reply += t("MODE.SET", { mode: settings[category].mode }) + "\n";
+        return await editReply(reply);
+      },
+      deaths: async () => {
+        const category = "deaths";
         settings = getCommonOptions(settings, category, interaction);
 
         const mode = interaction.options.getString("mode");

--- a/server/src/interfaces/bot/controllers/events.js
+++ b/server/src/interfaces/bot/controllers/events.js
@@ -26,10 +26,14 @@ async function subscribe(client) {
 
         const guildEvent = getTrackedEvent(event, trackByGuild[guild.id]);
         if (!guildEvent) continue;
-        addRankingKill(guild.id, guildEvent, trackByGuild[guild.id]);
 
-        const { enabled, channel, mode } = guild.settings.kills;
-        if (!enabled || !channel) continue;
+        const { enabled, channel, mode } = guildEvent.good ? guild.settings.kills : guild.settings.deaths;
+        if (!enabled || !channel) {
+          logger.verbose(`Skipping sending event ${event.EventId} to "${guild.name}" (disabled or no channel).`);
+          continue;
+        }
+
+        addRankingKill(guild.id, guildEvent, trackByGuild[guild.id]);
 
         logger.info(`Sending event ${event.EventId} to "${guild.name}".`);
         const locale = guild.settings.lang;

--- a/server/src/services/settings.js
+++ b/server/src/services/settings.js
@@ -13,6 +13,11 @@ const DEFAULT_SETTINGS = {
     channel: null,
     mode: REPORT_MODES.IMAGE,
   },
+  deaths: {
+    enabled: true,
+    channel: null,
+    mode: REPORT_MODES.IMAGE,
+  },
   battles: {
     enabled: true,
     channel: null,


### PR DESCRIPTION
# Description

- Create migration
- Make death settings effective
- Add deaths to default settings
- Update /settings command
- Refactor settings in dashboard to add death settings
- Create tabs styles override
- Update dependencies
- Remove titles from dashboard sub pages
- Fix borders for cards and other components

Fixes #151

# PR Checklist

- [ ] I tested my changes locally
- [ ] I added new tests (if applicabble)
- [ ] I guaranteed that the coverage will not to red threshold
- [ ] I updated the Documentation accordingly
