### PR TITLE
feat: Free Server limit messages

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -2,23 +2,26 @@
 # Global Settings #
 # --------------- #
 
-# Discord Bot Token (Required)
+# (Required) Discord Bot Token
 DISCORD_TOKEN=
-# Discord Client Id (Required)
+# (Required) Discord Client Id
 DISCORD_CLIENT_ID=
-# Discord Client Secret (Required)
+# (Required) Discord Client Secret
 DISCORD_CLIENT_SECRET=
-# Admin user ids (Use discord ids separated by commas. Ex: 155377266568855552,299505929018146816)
+# (Recommended) Admin user ids (Use discord ids separated by commas. Ex: 155377266568855552,299505929018146816)
 DISCORD_COMMUNITY_ADMINS=
-# Community server id
+# (Recommended) Community server id
 DISCORD_COMMUNITY_SERVER=
-# Premium role id to give users
+# (Recommended) Premium role id to give users
 DISCORD_COMMUNITY_PREMIUM_ROLE=
 
-# MongoDB database URI to store server configurations, cookie sessions and bot data (Required: api, bot)
+# (Required) Dashboard url (used for redirects, ex: http://localhost)
+DASHBOARD_URL=
+
+# (Required) MongoDB database URI to store server configurations, cookie sessions and bot data
 MONGODB_URL=
 
-# AMQP service URI to send events and battles queue (Required: bot, crawler)
+# (Required) AMQP service URI to send events and battles queue (Required: bot, crawler)
 AMQP_URL=
 # Maximum queued items (Default: 10000)
 AMQP_QUEUE_MAX_LENGTH=
@@ -26,6 +29,11 @@ AMQP_QUEUE_MAX_LENGTH=
 AMQP_QUEUE_BATTLES_BATCH=
 # Publish kills in batches instead of individual publish
 AMQP_QUEUE_EVENTS_BATCH=
+
+# (Optional) Default limits for free servers (Default: 10 players, 1 guild and 1 alliance)
+MAX_PLAYERS=
+MAX_GUILDS=
+MAX_ALLIANCES=
 
 # (Optional) Debug level for console, can be one of: error, warn, info, http, verbose, debug, silly (Default: info)
 DEBUG_LEVEL=
@@ -36,28 +44,26 @@ LOGGLY_TOKEN=
 # Loggly subdomain (Required to enable)
 LOGGLY_SUBDOMAIN=
 
+# ---------------------------------------- #
+# Feature toggles (disabled if left blank) #
+# ---------------------------------------- #
+
 # (Optional) Subscription mode (Default: false)
 # When this is enabled, servers can have a subscription with a expire date that allows them to have custom limits for tracking.
 SUBSCRIPTIONS_MODE=
-
-# Default limits for free servers (Default: 10 players, 1 guild and 1 alliance)
-MAX_PLAYERS=
-MAX_GUILDS=
-MAX_ALLIANCES=
 # Default limits for premium servers (Default: Use the limits of free servers)
 SUB_MAX_PLAYERS=
 SUB_MAX_GUILDS=
 SUB_MAX_ALLIANCES=
 
-# Feature toggles (disabled if left blank)
-# Fetch and display guild rankings (pvp, pve, gathering, crafting)
+# (Optional) Fetch and display guild rankings (pvp, pve, gathering, crafting) (Default: false)
 GUILD_RANKINGS=true
 
 # ------------ #
 # Bot Settings #
 # ------------ #
 
-# Total bot Shards (Default: 'auto')
+# (Optional) Total bot Shards (Default: 'auto')
 TOTAL_SHARDS=
 
 # (Optional) AWS Settings for caching kill item images.
@@ -75,12 +81,10 @@ AWS_BUCKET=
 # API Settings #
 # ------------ #
 
-# Discord redirect uri (Required)
-DISCORD_REDIRECT_URL=
-# Session Secret to encrypt session ids in the API (Recommended)
+# (Recommended) Session Secret to encrypt session ids in the API
 SESSION_SECRET=
 
-# Rate limit settins for the API (Recommended)
+# (Recommended) Rate limit settins for the API
 # Window in ms (Default: 60000 [60 seconds])
 RATE_LIMIT_WINDOW=
 # Number of requests allowed in that window (Default: 0 [unlimited])
@@ -94,5 +98,3 @@ STRIPE_ACCESS_TOKEN=
 STRIPE_PRODUCT=
 # Stripe Wehbook secret
 STRIPE_WEBHOOK_SECRET=
-# Stripe Redirect url after purchase
-STRIPE_REDIRECT_URL=

--- a/server/src/assets/locales/en.json
+++ b/server/src/assets/locales/en.json
@@ -114,18 +114,21 @@
   "TRACK": {
     "ALLIANCES": {
       "DESCRIPTION": "Alliance ID",
-      "NAME": "Alliances ({{ actual }}/{{ max }})",
+      "TITLE": "Alliances ({{ actual }}/{{ max }})",
       "TRACKED": "Tracking alliance: {{ name }}.",
+      "TYPE": "Alliances",
       "UNTRACKED": "Untracking alliance: {{ name }}."
     },
     "ALREADY_TRACKED": "I am already tracking this item.",
     "ERRORS": {
       "FETCH_FAILED": "Unable to fetch track settings. Please try again later."
     },
+    "FREE_LIMIT_REACHED": "You reached the limit of {{ limit }} {{ type }} for free servers. Upgrading to the Premium status will increase your slots to {{ premiumLimit }} {{ type }}. For more details, please visit the [premium page]({{{ url }}}).",
     "GUILDS": {
       "DESCRIPTION": "Guild name",
-      "NAME": "Guilds ({{ actual }}/{{ max }})",
+      "TITLE": "Guilds ({{ actual }}/{{ max }})",
       "TRACKED": "Tracking guild: {{ name }}.",
+      "TYPE": "Guilds",
       "UNTRACKED": "Untracking guild: {{ name }}."
     },
     "LIMIT_REACHED": "You already reached the limit of {{ limit }} items in this list.",
@@ -135,12 +138,13 @@
     "NOT_FOUND": "Sorry, I couldn't find anything with this name.",
     "PLAYERS": {
       "DESCRIPTION": "Player name",
-      "NAME": "Players ({{ actual }}/{{ max }})",
+      "TITLE": "Players ({{ actual }}/{{ max }})",
       "TRACKED": "Tracking player: {{ name }}.",
+      "TYPE": "Players",
       "UNTRACKED": "Untracking player: {{ name }}."
     },
     "SEARCH_FAILED": "Failed to fetch data from game servers. Please try again.",
-    "TRACKING_DISABLED": "Sorry, tracking of {{type}} is disabled for now. Please contact bot admin for more information.",
+    "TRACKING_DISABLED": "Sorry, tracking of {{ type }} is disabled. Please contact bot admin for more information.",
     "UNSUPPORTED_TYPE": "Unsupported type of tracking. Type !help to see more."
   },
   "VERSION": {

--- a/server/src/assets/locales/es.json
+++ b/server/src/assets/locales/es.json
@@ -114,18 +114,21 @@
   "TRACK": {
     "ALLIANCES": {
       "DESCRIPTION": "Alliance ID",
-      "NAME": "Alianzas ({{ actual }}/{{ max }})",
+      "TITLE": "Alianzas ({{ actual }}/{{ max }})",
       "TRACKED": "Alianza rastreada: {{ name }}.",
+      "TYPE": "Alianzas",
       "UNTRACKED": "Dejar de rastrear Alianza: {{ name }}."
     },
     "ALREADY_TRACKED": "Ya estoy rastreando este artículo.",
     "ERRORS": {
       "FETCH_FAILED": "No se puede obtener la configuración de la pista. Por favor, inténtelo de nuevo más tarde."
     },
+    "FREE_LIMIT_REACHED": "Alcanzaste el límite de {{ limit }} {{ type }} para servidores gratuitos. Actualizar al estado Premium aumentará sus espacios a {{ premiumLimit }} {{ type }}. Para obtener más detalles, visite la [página premium]({{{ url }}}).",
     "GUILDS": {
       "DESCRIPTION": "Guild name",
-      "NAME": "Gremios ({{ actual }}/{{ max }})",
+      "TITLE": "Gremios ({{ actual }}/{{ max }})",
       "TRACKED": "Gremio rastreado: {{ name }}.",
+      "TYPE": "Gremios",
       "UNTRACKED": "Dejar de rastrear gremio: {{ name }}."
     },
     "LIMIT_REACHED": "Limite Alcanzado de {{ limit }} articulos en esta lista.",
@@ -135,12 +138,13 @@
     "NOT_FOUND": "Lo siento, no pude encontrar nada con este nombre.",
     "PLAYERS": {
       "DESCRIPTION": "Player name",
-      "NAME": "Jugadores ({{ actual }}/{{ max }})",
+      "TITLE": "Jugadores ({{ actual }}/{{ max }})",
       "TRACKED": "Jugador rastreado: {{ name }}.",
+      "TYPE": "Jugadores",
       "UNTRACKED": "Dejar de rastrear Jugador: {{ name }}."
     },
     "SEARCH_FAILED": "Failed to fetch data from Albion Servers. Please try again.",
-    "TRACKING_DISABLED": "Lo sentimos, el seguimiento de {{ type }} está deshabilitado por ahora. Póngase en contacto con el administrador de bot para obtener más información.",
+    "TRACKING_DISABLED": "Lo sentimos, el seguimiento de {{ type }} está deshabilitado. Póngase en contacto con el administrador de bot para obtener más información.",
     "UNSUPPORTED_TYPE": "Tipo de seguimiento no compatible. Escriba !Help para ver más."
   },
   "VERSION": {

--- a/server/src/assets/locales/fr.json
+++ b/server/src/assets/locales/fr.json
@@ -114,18 +114,21 @@
   "TRACK": {
     "ALLIANCES": {
       "DESCRIPTION": "Alliance ID",
-      "NAME": "Alliances ({{ actual }}/{{ max }})",
+      "TITLE": "Alliances ({{ actual }}/{{ max }})",
       "TRACKED": "Suivi de l'alliance: {{ name }}.",
+      "TYPE": "Alliances",
       "UNTRACKED": "Désactivation de la suivi de l'alliance: {{ name }}."
     },
     "ALREADY_TRACKED": "Je suis déja ceci.",
     "ERRORS": {
       "FETCH_FAILED": "Impossible de récupérer les paramètres de suivi. Veuillez réessayer plus tard."
     },
+    "FREE_LIMIT_REACHED": "Vous avez atteint la limite de {{ limit }} {{ type }} pour les serveurs gratuits. La mise à niveau vers le statut Premium augmentera vos emplacements à {{ premiumLimit }} {{ type }}. Pour plus de détails, veuillez visiter la [page premium]({{{ url }}}).",
     "GUILDS": {
       "DESCRIPTION": "Guild name",
-      "NAME": "Guildes ({{ actual }}/{{ max }})",
+      "TITLE": "Guildes ({{ actual }}/{{ max }})",
       "TRACKED": "Suivi de la guilde: {{ name }}.",
+      "TYPE": "Guildes",
       "UNTRACKED": "Désactivation de la suivi de la guilde: {{ name }}."
     },
     "LIMIT_REACHED": "Tu as déja atteint la limite de {{ limit }} suivis dans la liste..",
@@ -135,12 +138,13 @@
     "NOT_FOUND": "Désolé, je ne trouve rien portant ce nom",
     "PLAYERS": {
       "DESCRIPTION": "Player name",
-      "NAME": "Joueurs ({{ actual }}/{{ max }})",
+      "TITLE": "Joueurs ({{ actual }}/{{ max }})",
       "TRACKED": "Suivi du joueur: {{ name }}.",
+      "TYPE": "Joueurs",
       "UNTRACKED": "Désactivation de la suivi du joueur: {{ name }}."
     },
     "SEARCH_FAILED": "Impossible de récupérer les données depuis les serveurs d'Albion Online. Rééssayez plus tard.",
-    "TRACKING_DISABLED": "Désolé, le suivi d'{{ type }} est désactivé. Contacter l'administrateur pour plus d'informations.",
+    "TRACKING_DISABLED": "Désolé, le suivi de {{ type }} est désactivé. Veuillez contacter l'administrateur du bot pour plus d'informations.",
     "UNSUPPORTED_TYPE": "Je ne peux pas suivre ceci. Ecrivez !help pour en savoir plus."
   },
   "VERSION": {

--- a/server/src/assets/locales/pt.json
+++ b/server/src/assets/locales/pt.json
@@ -114,18 +114,21 @@
   "TRACK": {
     "ALLIANCES": {
       "DESCRIPTION": "ID da aliança",
-      "NAME": "Alianças ({{ actual }}/{{ max }})",
+      "TITLE": "Alianças ({{ actual }}/{{ max }})",
       "TRACKED": "Rastreando aliança: {{ name }}.",
+      "TYPE": "Alianças",
       "UNTRACKED": "Parando de rastrear aliança: {{ name }}."
     },
     "ALREADY_TRACKED": "Já estou rastreando este item.",
     "ERRORS": {
       "FETCH_FAILED": "Não foi possível recuperar informações de rastreamento. Tente novamente mais tarde."
     },
+    "FREE_LIMIT_REACHED": "Você atingiu o limite de {{ limit }} {{ type }} para servidores gratuitos. A atualização para o status Premium aumentará seus slots para {{ premiumLimit }} {{ type }}. Para mais detalhes, visite a [página premium]({{{ url }}}).",
     "GUILDS": {
       "DESCRIPTION": "Nome da guilda",
-      "NAME": "Guildas ({{ actual }}/{{ max }})",
+      "TITLE": "Guildas ({{ actual }}/{{ max }})",
       "TRACKED": "Rastreando guilda: {{ name }}.",
+      "TYPE": "Guildas",
       "UNTRACKED": "Parando de rastrear guilda: {{ name }}."
     },
     "LIMIT_REACHED": "Você atingiu o limite de {{ limit }} itens nesta lista.",
@@ -135,12 +138,13 @@
     "NOT_FOUND": "Desculpe, não consegui encontrar nada com este nome.",
     "PLAYERS": {
       "DESCRIPTION": "Nome do jogador",
-      "NAME": "Jogadores ({{ actual }}/{{ max }})",
+      "TITLE": "Jogadores ({{ actual }}/{{ max }})",
       "TRACKED": "Rastreando jogador: {{ name }}.",
+      "TYPE": "Jogadores",
       "UNTRACKED": "Parando de rastrear jogador: {{ name }}."
     },
     "SEARCH_FAILED": "Falha ao buscar dados nos servidores do jogo. Por favor, tente novamente.",
-    "TRACKING_DISABLED": "Desculpe, rastreamento de {{ type }} está desabilitado por enquanto. Consulte o administrador do bot para mais informações.",
+    "TRACKING_DISABLED": "Desculpe, o rastreamento de {{ type }} está desativado. Entre em contato com o administrador do bot para obter mais informações.",
     "UNSUPPORTED_TYPE": "Tipo de rastreamento não suportado. Digite !help para ver mais."
   },
   "VERSION": {

--- a/server/src/assets/locales/ru.json
+++ b/server/src/assets/locales/ru.json
@@ -114,18 +114,21 @@
   "TRACK": {
     "ALLIANCES": {
       "DESCRIPTION": "Alliance ID",
-      "NAME": "Альянсы ({{ actual }}/{{ max }})",
+      "TITLE": "Альянсы ({{ actual }}/{{ max }})",
       "TRACKED": "Отслеживание альянса: {{ name }}.",
+      "TYPE": "Альянсы",
       "UNTRACKED": "Прекращение отслеживание альянса: {{ name }}."
     },
     "ALREADY_TRACKED": "Я уже отслеживаю это.",
     "ERRORS": {
       "FETCH_FAILED": "Не удалось загрузить настройки отслеживания. Пожалуйста, повторите попытку позже."
     },
+    "FREE_LIMIT_REACHED": "Вы достигли предела {{ limit }} {{ type }} для бесплатных серверов. Повышение статуса до Premium увеличит ваши слоты до {{ premiumLimit }} {{ type }}. Для получения более подробной информации посетите [премиум-страницу]({{{ url }}}).",
     "GUILDS": {
       "DESCRIPTION": "Guild name",
-      "NAME": "Гильдии ({{ actual }}/{{ max }})",
+      "TITLE": "Гильдии ({{ actual }}/{{ max }})",
       "TRACKED": "Отслеживание гильдии: {{ name }}.",
+      "TYPE": "Гильдии",
       "UNTRACKED": "Прекращение отслеживание гильдии: {{ name }}."
     },
     "LIMIT_REACHED": "Вы уже достигли лимита {{ limit }} элементов в этом списке.",
@@ -135,12 +138,13 @@
     "NOT_FOUND": "К сожалению, я не смог найти ничего с таким именем.",
     "PLAYERS": {
       "DESCRIPTION": "Player name",
-      "NAME": "Игроки ({{ actual }}/{{ max }})",
+      "TITLE": "Игроки ({{ actual }}/{{ max }})",
       "TRACKED": "Отслеживание игрока: {{ name }}.",
+      "TYPE": "Игроки",
       "UNTRACKED": "Прекращение отслеживание игрока: {{ name }}."
     },
     "SEARCH_FAILED": "Failed to fetch data from Albion Servers. Please try again.",
-    "TRACKING_DISABLED": "Sorry, tracking of {{ type }} is disabled for now. Please contact bot admin for more information.",
+    "TRACKING_DISABLED": "К сожалению, отслеживание {{ type }} отключено. Пожалуйста, свяжитесь с администратором бота для получения дополнительной информации.",
     "UNSUPPORTED_TYPE": "Неподдерживаемый тип. Введите !help чтобы увидеть больше"
   },
   "VERSION": {

--- a/server/src/ports/adapters/discordApiClient.js
+++ b/server/src/ports/adapters/discordApiClient.js
@@ -6,7 +6,7 @@ const TOKEN_ENDPOINT = "/oauth2/token";
 const USERS_ENDPOINT = "/users";
 const GUILDS_ENDPOINT = "/guilds";
 
-const { DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, DISCORD_REDIRECT_URL } = process.env;
+const { DASHBOARD_URL, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET } = process.env;
 
 const discordApiClient = axios.create({
   baseURL: "https://discord.com/api/v10",
@@ -34,7 +34,7 @@ async function exchangeCode(code) {
   params.append("client_secret", DISCORD_CLIENT_SECRET);
   params.append("grant_type", "authorization_code");
   params.append("code", code);
-  params.append("redirect_uri", DISCORD_REDIRECT_URL);
+  params.append("redirect_uri", `${DASHBOARD_URL}/auth`);
 
   const res = await discordApiClient.post(TOKEN_ENDPOINT, params);
   return res.data;

--- a/server/src/ports/stripe.js
+++ b/server/src/ports/stripe.js
@@ -1,7 +1,7 @@
 const Stripe = require("stripe");
 const logger = require("../helpers/logger");
 
-const { STRIPE_ACCESS_TOKEN, STRIPE_PRODUCT, STRIPE_REDIRECT_URL } = process.env;
+const { DASHBOARD_URL, STRIPE_ACCESS_TOKEN, STRIPE_PRODUCT } = process.env;
 
 const isEnabled = STRIPE_ACCESS_TOKEN && STRIPE_PRODUCT;
 const stripe = Stripe(STRIPE_ACCESS_TOKEN, {
@@ -36,8 +36,8 @@ async function getPrices({ currency = "usd", product = STRIPE_PRODUCT }) {
 async function createCheckoutSession(priceId, owner) {
   try {
     const checkout = await stripe.checkout.sessions.create({
-      success_url: `${STRIPE_REDIRECT_URL}?status=success&checkout_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${STRIPE_REDIRECT_URL}?status=cancel`,
+      success_url: `${DASHBOARD_URL}/premium?status=success&checkout_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${DASHBOARD_URL}/premium?status=cancel`,
       client_reference_id: owner,
       mode: "subscription",
       line_items: [
@@ -63,7 +63,7 @@ async function createPortalSession(customerId) {
   try {
     const session = await stripe.billingPortal.sessions.create({
       customer: customerId,
-      return_url: STRIPE_REDIRECT_URL,
+      return_url: `${DASHBOARD_URL}/premium`,
     });
 
     return {

--- a/server/src/services/images.js
+++ b/server/src/services/images.js
@@ -6,7 +6,6 @@ const { getItemFile } = require("../ports/albion");
 const { optimizeImage } = require("../helpers/images");
 const { digitsFormatter, fileSizeFormatter } = require("../helpers/utils");
 const logger = require("../helpers/logger");
-const F = require("fast-redact");
 
 const assetsPath = path.join(__dirname, "..", "assets");
 

--- a/server/src/services/limits.js
+++ b/server/src/services/limits.js
@@ -35,6 +35,14 @@ async function getLimits(serverId) {
   });
 }
 
+function getPremiumLimits() {
+  return {
+    players: SUB_MAX_PLAYERS,
+    guilds: SUB_MAX_GUILDS,
+    alliances: SUB_MAX_ALLIANCES,
+  };
+}
+
 async function updateLimitsCache(timeout) {
   const subscriptions = await fetchAllSubscriptions();
   subscriptions.forEach((subscription) => {
@@ -47,5 +55,6 @@ async function updateLimitsCache(timeout) {
 
 module.exports = {
   getLimits,
+  getPremiumLimits,
   updateLimitsCache,
 };


### PR DESCRIPTION
# Description

- Update .env.example for the upcoming dashboard url variable
- Replace XXX_REDIRECT_URL for DASHBOARD_URL
- Add messages tell users that the free servers limits are reached

# PR Checklist

- [ ] I tested my changes locally
- [ ] I added new tests (if applicabble)
- [ ] I guaranteed that the coverage will not to red threshold
- [ ] I updated the Documentation accordingly
